### PR TITLE
Use Thin instead of Webrick for our dev server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,4 +122,7 @@ group :test, :development do
   # Required to populate the database with load-test data for Convictions.
   gem 'elasticsearch-persistence', '~> 0.1.6'
   gem 'ruby-progressbar', '>= 1.7.1'
+
+  # Development web server
+  gem 'thin'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
     currencies (0.4.2)
+    daemons (1.2.3)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
@@ -150,6 +151,7 @@ GEM
       multi_json
     equalizer (0.0.9)
     erubis (2.7.0)
+    eventmachine (1.2.0.1)
     execjs (2.2.2)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -333,6 +335,10 @@ GEM
       net-ssh (>= 2.8.0)
     temple (0.6.10)
     terminal-table (1.4.5)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -415,6 +421,7 @@ DEPENDENCIES
   selenium-webdriver (~> 2.44.0)
   shoulda-matchers
   simplecov
+  thin
   timecop (~> 0.7.1)
   turbolinks
   turnout (~> 2.1.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,9 +55,6 @@ Registrations::Application.configure do
   #will redirect the user to a suitable entry point, such as the 'Find out if I need to register' page
   config.show_developer_index_page = true
 
-  # this allows WEBrick to handle caret symbols in query parameters; needed for Worldpay
-  URI::DEFAULT_PARSER = URI::Parser.new(:UNRESERVED => URI::REGEXP::PATTERN::UNRESERVED + '^')
-
   # require access via www or admin service domain URLs for testing
   config.require_admin_requests = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,9 +46,6 @@ Registrations::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  # this allows WEBrick to handle caret symbols in query parameters; needed for Worldpay
-  URI::DEFAULT_PARSER = URI::Parser.new(:UNRESERVED => URI::REGEXP::PATTERN::UNRESERVED + '^')
-
   # require access via www or admin service domain URLs for testing
   config.require_admin_requests = false
 


### PR DESCRIPTION
This resolves the constant warnings in the console where we override the URI default parser. Should be a bit quicker too. Handles caret characters in the URL just fine.
