### PR TITLE
Update Airbrake gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '4.0.12'
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
 # For exception logging.
-gem 'airbrake', '~> 5.2'
+gem 'airbrake', '~> 5.3'
 
 # We store user accounts (authentication with Devise) in a MongoDB database
 gem 'mongoid', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,9 +30,9 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     addressable (2.3.6)
-    airbrake (5.2.3)
-      airbrake-ruby (~> 1.2)
-    airbrake-ruby (1.3.0)
+    airbrake (5.3.0)
+      airbrake-ruby (~> 1.3)
+    airbrake-ruby (1.3.1)
     arel (4.0.2)
     awesome_print (1.6.1)
     axiom-types (0.1.1)
@@ -370,7 +370,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeresource (~> 4.0.0)
-  airbrake (~> 5.2)
+  airbrake (~> 5.3)
   awesome_print
   better_errors
   binding_of_caller


### PR DESCRIPTION
Fixes bug with Airbrake 5.2 gem incorrectly handling exceptions
