### PR TITLE
Filter passwords in params before going to Airbrake

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -3,5 +3,7 @@ if ENV['WCRS_FRONTEND_USE_AIRBRAKE'] && !Rails.env.test?
     config.host = ENV['WCRS_FRONTEND_AIRBRAKE_HOST']
     config.project_id = ENV['WCRS_FRONTEND_AIRBRAKE_PROJECT_ID']
     config.project_key = ENV['WCRS_FRONTEND_AIRBRAKE_PROJECT_KEY']
+    config.root_directory = Rails.root
+    config.blacklist_keys = [/password/i]
   end
 end


### PR DESCRIPTION
Also set Airbrake root path to remove repetitive path information (I think this includes the scenario @TThurston where you see `/home/lewis/projects/waste-exemplar..` etc in the Slack channel.
