### PR TITLE
Update date-of-birth validation rules

### DIFF
--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -21,9 +21,9 @@ class KeyPerson < Ohm::Model
   VALID_MONTH = /\A[0-9]{2}/
   VALID_YEAR = /\A[0-9]{4}/
 
-  MAX_ALLOWED_AGE = 130.years
+  MAX_ALLOWED_AGE = 110.years
   MIN_DIRECTOR_AGE = 16.years
-  MIN_NON_DIRECTOR_AGE = 18.years
+  MIN_NON_DIRECTOR_AGE = 17.years
 
   before_validation :strip_whitespace, :only => [:dob_day, :dob_month, :dob_year]
 
@@ -134,7 +134,7 @@ class KeyPerson < Ohm::Model
             end
           else
             if dob.try(:>, Date.today-MIN_NON_DIRECTOR_AGE)
-              errors.add(:dob, I18n.t('errors.messages.non-director_dob_less_than_18_years'))
+              errors.add(:dob, I18n.t('errors.messages.non-director_dob_less_than_17_years'))
             end
           end
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,7 +310,7 @@ en:
       invalid_last_name: "The last name  can use letters, spaces and some special characters (-’). It must be no longer than 35 characters"
       blank_telephone: "You must enter a telephone number"
       invalid_telephone: "The telephone number can use numbers, spaces and some special characters (-+). It must be no longer than 20 characters"
-      non-director_dob_less_than_18_years: "You must be over 18 to use this service"
+      non-director_dob_less_than_17_years: "You must be over 17 to use this service"
       director_dob_less_than_16_years: "You must be over 16 to be a director of a private limited company in the UK"
 
       # Section 3 (convictions)

--- a/spec/models/key_person_spec.rb
+++ b/spec/models/key_person_spec.rb
@@ -10,45 +10,50 @@ describe KeyPerson do
 
   describe 'dob' do
 
-     context 'in the past but within 18 years' do
+     context 'in the past but within 17 years' do
       before do
-        subject.dob_day = '4'
+        subject.dob_day = '6'
         subject.dob_month = '7'
-        subject.dob_year = '2014'
+        subject.dob_year = '1997'
       end
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).not_to allow_value('4 Jul 2014'.to_date).for(:dob).with_message('You must be over 18 to use this service')
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(1)
+          expect(subject.errors[:dob]).to include('You must be over 17 to use this service')
         end
       end
     end
 
-    context 'in the past past but outside 18 years' do
+    context 'in the past past but outside 17 years' do
       before do
         subject.dob_day = '4'
         subject.dob_month = '7'
-        subject.dob_year = '1996'
+        subject.dob_year = '1997'
       end
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).to allow_value('4 Jul 2014'.to_date).for(:dob)
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(0)
         end
       end
     end
 
     context 'in the past but within 16 years' do
       before do
-        subject.dob_day = '4'
+        subject.dob_day = '6'
         subject.dob_month = '7'
-        subject.dob_year = '2014'
+        subject.dob_year = '1998'
         subject.position = 'Director'
       end
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).not_to allow_value('4 Jul 2014'.to_date).for(:dob).with_message('You must be over 16 to be a director of a private limited company in the UK')
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(1)
+          expect(subject.errors[:dob]).to include('You must be over 16 to be a director of a private limited company in the UK')
         end
       end
     end
@@ -63,46 +68,59 @@ describe KeyPerson do
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).to allow_value('4 Jul 1998'.to_date).for(:dob)
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(0)
         end
       end
     end
 
-    context 'in the past past but within 130 years' do
+    context 'in the past past but within 110 years' do
       before do
-        subject.dob_day = '4'
+        subject.dob_day = '6'
         subject.dob_month = '7'
-        subject.dob_year = '1996'
+        subject.dob_year = '1904'
       end
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).to allow_value('4 Jul 1996'.to_date).for(:dob)
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(0)
         end
       end
     end
 
-    context 'in the past but outside 130 years' do
+    context 'in the past but outside 110 years' do
       before do
         subject.dob_day = '4'
         subject.dob_month = '7'
-        subject.dob_year = '1884'
+        subject.dob_year = '1904'
       end
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).not_to allow_value('4 Jul 1884'.to_date).for(:dob).with_message('You must enter a valid date')
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(1)
+          expect(subject.errors[:dob]).to include('You must enter a valid date')
         end
       end
     end
 
     context 'today' do
-      Timecop.freeze('5 Jul 2014'.to_date) do
-        xit { should_not allow_value('5 Jul 2014'.to_date).for(:dob) }
+      before do
+        subject.dob_day = '5'
+        subject.dob_month = '7'
+        subject.dob_year = '2014'
+      end
+
+      it do
+        Timecop.freeze('5 Jul 2014'.to_date) do
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(1)
+        end
       end
     end
 
-    context 'in the futute' do
+    context 'in the future' do
       before do
         subject.dob_day = '6'
         subject.dob_month = '7'
@@ -111,7 +129,9 @@ describe KeyPerson do
 
       it do
         Timecop.freeze('5 Jul 2014'.to_date) do
-          expect(subject).not_to allow_value('6 Jul 2014'.to_date).for(:dob).with_message('The date must be in the past')
+          subject.valid?
+          expect(subject.errors[:dob].size).to eq(1)
+          expect(subject.errors[:dob]).to include('The date must be in the past')
         end
       end
     end


### PR DESCRIPTION
@lewispb - During review, could you pay particular attention to the RSpec file; the spec previously used an odd syntax where we passed a value for "dob" even though it looks like the code cannot "accept" this value.  I've updated the spec syntax but would like to hear if there is a preferred way to write these kind of specs (i.e. validation of a derived attribute).

Could you also review the dates used in the tests; I always have to think twice to make sure I'm getting the dates the right way around etc!
