### PR TITLE
Extend the Cucumber test for renewing an expired IR registration

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -493,6 +493,11 @@ class RegistrationsController < ApplicationController
 
   def commit_new_registration?
     unless @registration.tier == 'LOWER'
+      # ------------- Begin Note -----------------------------------------------
+      # NOTE: This code currently has no effect, as the Expiry Date is chosen by the
+      # Java services.  However, we leave it in as it may become useful if we ever
+      # remove the services tier.
+
       # Detect standard or IR renewal
       if @registration.originalRegistrationNumber && isIRRegistrationType(@registration.originalRegistrationNumber) && @registration.newOrRenew
         # This is an IR renewal, so set the expiry date to 3 years from the
@@ -502,6 +507,7 @@ class RegistrationsController < ApplicationController
         # This is a new registration; set the expiry date to 3 years from today.
         @registration.expires_on = (Date.current + Rails.configuration.registration_expires_after)
       end
+      # ------------- End Note -----------------------------------------------
     end
 
     # Note: we are assigning a unique identifier to the registration in order to

--- a/features/ir_registrations.feature
+++ b/features/ir_registrations.feature
@@ -21,6 +21,9 @@ Scenario: Expired IR registration, No convictions, Online payment
   And I make no other changes to my registration details
   Then I will be charged the full fee
   And registration should be complete when payment is successful
+  When I activate my account by clicking the link in the activation email
+  And I am logged in as waste carrier user 'joe@grades.co.uk'
+  Then my registration Certificate has a correct Expiry Date
 
 @javascript
 Scenario: IR registrations, Convictions, Online payment

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -182,7 +182,7 @@ end
 # TODO AH need to centralise date formatting and get expire date from services
 Then(/^my registration Certificate has a correct Expiry Date$/) do
   expectedExpiryDate = Date.today + Rails.configuration.registration_expires_after
-  first(:css, '.viewCertificate').click
+  visit first(:css, '.viewCertificate')[:href]
   expect(page).to have_text expectedExpiryDate.strftime('%A ' + expectedExpiryDate.mday.ordinalize + ' %B %Y')
 end
 


### PR DESCRIPTION
so that it checks that the user gets a full 3-year registration.
