### PR TITLE
Use thin with capybara

### DIFF
--- a/features/support/thin.rb
+++ b/features/support/thin.rb
@@ -1,0 +1,7 @@
+require 'thin'
+Thin::Logging.silent = true
+
+Capybara.server do |app, port|
+  require 'rack/handler/thin'
+  Rack::Handler::Thin.run(app, :Port => port)
+end


### PR DESCRIPTION
We now use the thin webserver in development so this enables it to be used in test too with capybara / cucumber.
