### PR TITLE
Always open "Certificate" page in a new tab.

### DIFF
--- a/app/views/registrations/finish.html.erb
+++ b/app/views/registrations/finish.html.erb
@@ -29,7 +29,7 @@
         <p><%= t '.details_emailed', :email => @registration.accountEmail %></p>
       <% end %>
       <% if can? :view, @registration and isComplete %>
-        <p><%= link_to t('form.view_certificate_link_label'), view_url(@registration.uuid), :class => 'link-button-secondary' %></p>
+        <p><%= link_to t('form.view_certificate_link_label'), view_url(@registration.uuid), { class: 'link-button-secondary', target: "_blank" } %></p>
       <% end %>
 
       <% unless @registration.paid_in_full? %>

--- a/app/views/registrations/finishAssisted.html.erb
+++ b/app/views/registrations/finishAssisted.html.erb
@@ -26,7 +26,7 @@
         </p>
 
         <% if can? :view, @registration %>
-          <p><%= link_to t('form.view_certificate_link_label'), view_url(@registration.uuid), { :class => 'link-button-secondary', :id => 'view_certificate'} %></p>
+          <p><%= link_to t('form.view_certificate_link_label'), view_url(@registration.uuid), { class: 'link-button-secondary', id: 'view_certificate', target: "_blank" } %></p>
         <% end %>
 
         <% else %>


### PR DESCRIPTION
Update to the Finish pages so that the link to View Certificate opens in a new tab.  Useful because the Certificate page now contains wording to the effect "you can close this tab...".
