### PR TITLE
Reset copy card quantity to zero for every new order.

### DIFF
--- a/app/controllers/order_controller.rb
+++ b/app/controllers/order_controller.rb
@@ -19,7 +19,7 @@ class OrderController < ApplicationController
 
     renderNotFound && return unless @registration
 
-    @registration.copy_cards ||= 0
+    @registration.copy_cards = 0
     @registration.update(copy_card_only_order: 'yes') if Order.extra_copycards_identifier == @renderType
 
     @registration.order_builder.current_user = current_user || current_agency_user


### PR DESCRIPTION
To illustrate why this is necessary, consider the following scenario.  User registers and pays.  User then logs-in some time later, and initiates an order for 2 copy cards, but does not complete payment.  They then edit the registration, changing carrier type, triggering the £40 charge, and go to the Order screen.  Without this fix, the screen would show "Edit Registration: £40", "Total charge: £50", because two copy cards are still being added to the order, albeit silently, by the order builder, due to the cached copy card quantity on the registration object from the earlier order.  By reseting the CC quantity to zero for each new order, we avoid this.
