### PR TITLE
Remove bank transfer email text

### DIFF
--- a/app/views/registration_mailer/awaitingConvictionsCheck_email.html.erb
+++ b/app/views/registration_mailer/awaitingConvictionsCheck_email.html.erb
@@ -73,8 +73,6 @@
             <ul>
               <li style="font-size: 16px; font-weight:bold; line-height: 1.315789474;margin: 0 0 30px 0;">
                 <%= t 'registration_mailer.awaitingConvictionsCheck.paragraph2' %></li>
-              <li style="font-size: 16px; line-height: 1.315789474;margin: 0 0 30px 0;">
-                <%= t 'registration_mailer.awaitingConvictionsCheck.paragraph3' %></li>
             </ul>
 
             <ul>

--- a/app/views/registration_mailer/awaitingPayment_email.html.erb
+++ b/app/views/registration_mailer/awaitingPayment_email.html.erb
@@ -169,8 +169,6 @@
 
                <ul>
                 <li style="font-size: 16px; font-weight:bold; line-height: 1.315789474;margin: 0 0 30px 0;"><%= t 'registration_mailer.awaitingPayment.paragraph9' %></li>
-                <li style="font-size: 16px; line-height: 1.315789474;margin: 0 0 30px 0;">
-                  <%= t 'registration_mailer.awaitingPayment.paragraph10' %></li>
                </ul>
 
               </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -622,7 +622,6 @@ en:
       heading: "What happens next:"
       paragraph1: "We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days."
       paragraph2: "You’re not legally entitled to operate as a waste carrier until we have received your payment and confirmed your registration"
-      paragraph3: "We probably won’t take action against you for operating while we’re waiting for your payment to come through. But the police or your local council might"
     awaitingPayment:
       heading: "Application received"
       app_received: "Application received"
@@ -651,7 +650,6 @@ en:
       pretext12: "Postal address:\ "
       paragraph8: "Please allow 5 working days for your payment to reach us."
       paragraph9: "You’re not legally entitled to operate as a waste carrier until we have received your payment and confirmed your registration"
-      paragraph10: "We probably won’t take action against you for operating while we’re waiting for your payment to come through. But the police or your local council might"
       payment_notice: "Payment notice"
     account_already_confirmed:
       title: "Waste Carriers Service"


### PR DESCRIPTION
https://trello.com/c/usSbevii/24-19-bank-transfer-email-text

Remove the following line:

We probably won’t take action against you for operating while we’re waiting for your payment to come through. But the police or your local council might.
