### PR TITLE
Cache the Registration Order object in the New Configuration view

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -123,6 +123,7 @@ class RegistrationsController < ApplicationController
   def newConfirmation
     new_step_action 'confirmation'
     return unless @registration
+    @registration_order = @registration.registration_order
   end
 
   # POST /your-registration/confirmation

--- a/app/views/registrations/newConfirmation.html.erb
+++ b/app/views/registrations/newConfirmation.html.erb
@@ -28,7 +28,7 @@
       <%= form_for(@registration, :url => newConfirmation_path, html: {autocomplete: 'off'}) do |f| %>
 
       <div class="text registration-tier">
-        <% if (@registration.order_types.include?(:new) || @registration.lower?) && !@registration.registration_order.is_attempting_renewal? %>
+        <% if (@registration.order_types.include?(:new) || @registration.lower?) && !@registration_order.is_attempting_renewal? %>
           <div class="text">
             <p><%= t('.tier_result_message', tier_with_article: @registration.tier.downcase.with_indefinite_article) %></p>
             <% if @registration.upper? %>
@@ -37,12 +37,12 @@
           </div>
         <% end %>
 
-        <% if @registration.registration_order.is_attempting_renewal? %>
+        <% if @registration_order.is_attempting_renewal? %>
           <div class='text'>
-            <p><%= @registration.registration_order.within_ir_renewal_window? ? t('.subtitle_renew_reg') : t('.subtitle_renew_expired_reg') %></p>
+            <p><%= @registration_order.within_ir_renewal_window? ? t('.subtitle_renew_reg') : t('.subtitle_renew_expired_reg') %></p>
             <p><%= t('.tier_result_message', tier_with_article: @registration.tier.downcase.with_indefinite_article) %></p>
             <% if @registration.upper? %>
-              <% if @registration.registration_order.within_ir_renewal_window? %>
+              <% if @registration_order.within_ir_renewal_window? %>
                 <p><%= t('.renewal_payment_message', fee: humanized_money_with_symbol(@registration.order_builder.registration_fee_money)) %></p>
               <% else %>
                 <p><%= t('.expired_renewal_payment_message', fee: humanized_money_with_symbol(@registration.order_builder.registration_fee_money)) %></p>

--- a/spec/views/registrations/newConfirmation.html.erb_spec.rb
+++ b/spec/views/registrations/newConfirmation.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe 'registrations/newConfirmation', type: :view do
 
     it 'displays the correct charge wording' do
       assign(:registration, subject)
+      assign(:registration_order, subject.registration_order)
       render
 
       expect(rendered).to have_text("Based on the information you provided, you are an upper tier waste carrier.")
@@ -24,6 +25,7 @@ describe 'registrations/newConfirmation', type: :view do
     it 'displays the correct charge wording' do
       RegistrationOrder.any_instance.stub(:ir_renewal).and_return(subject)
       assign(:registration, subject)
+      assign(:registration_order, subject.registration_order)
       render
 
       expect(rendered).to have_text("The renewal charge is £105, which will register you for 3 years.")
@@ -40,6 +42,7 @@ describe 'registrations/newConfirmation', type: :view do
       flash[:start_editing] = true # normally set on the previous page (user registration list)
       RegistrationOrder.any_instance.stub(:original_registration).and_return(subject)
       assign(:registration, subject)
+      assign(:registration_order, subject.registration_order)
       render
 
       expect(rendered).to have_text("Editing your registration")
@@ -51,6 +54,7 @@ describe 'registrations/newConfirmation', type: :view do
       subject.registrationType = 'carrier_dealer'
       subject.save
       assign(:registration, subject)
+      assign(:registration_order, subject.registration_order)
       render
 
       expect(rendered).to have_text("Editing your registration")
@@ -65,6 +69,7 @@ describe 'registrations/newConfirmation', type: :view do
       RegistrationOrder.any_instance.stub(:ir_renewal).and_return(create(:registration, :ir_renewal))
       editing_renewal_registration = create(:registration, :ir_renewal, :editing, registrationType: 'carrier_dealer')
       assign(:registration, editing_renewal_registration)
+      assign(:registration_order, editing_renewal_registration.registration_order)
       render
 
       expect(rendered).to have_text("You are about to renew your registration.")
@@ -79,6 +84,7 @@ describe 'registrations/newConfirmation', type: :view do
       RegistrationOrder.any_instance.stub(:ir_renewal).and_return(create(:registration, :ir_renewal))
       editing_renewal_registration = create(:registration, :ir_renewal, :editing, businessType: 'soleTrader') # changing to soleTrader triggers change caused new
       assign(:registration, editing_renewal_registration)
+      assign(:registration_order, editing_renewal_registration.registration_order)
       render
 
       expect(rendered).to have_text("You are about to renew your registration.")
@@ -95,6 +101,7 @@ describe 'registrations/newConfirmation', type: :view do
 
       renewal_registration = create(:registration, :ir_renewal, originalDateExpiry: Date.today - 3.months)
       assign(:registration, renewal_registration)
+      assign(:registration_order, renewal_registration.registration_order)
       render
 
       expect(rendered).to have_text("Your previous registration has expired.")


### PR DESCRIPTION
Should mean fewer calls to the Java services (and hence Mongo too).
