### PR TITLE
Ensure route is set

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -91,6 +91,7 @@ module RegistrationsHelper
 
     if !session[:editing] && current_step != 'payment' && current_step != 'confirmation'
       logger.debug 'Registration is not editable anymore. Cannot access page - current_step = ' + current_step.to_s
+      Airbrake.notify(RuntimeError.new('Registration is not editable, redirected to cannot_edit_path'))
       redirect_to cannot_edit_path and return
     end
 
@@ -141,7 +142,7 @@ module RegistrationsHelper
       session[:registration_uuid] ||= @registration.uuid
     else
       logger.warn {'There is no @registration. Redirecting to the Cookies page'}
-      Airbrake.notify(RuntimeError.new('Failed to get @registration in setup_registration()'))
+      Airbrake.notify(RuntimeError.new("Failed to get @registration in setup_registration(), session[:registration_id] is #{session[:registration_id]} and params[:id] is #{params[:id]}"))
       redirect_to cookies_path
       return
     end
@@ -161,6 +162,7 @@ module RegistrationsHelper
     elsif  session[:edit_mode] #editing existing registration
       if !session[:editing] && current_step != 'payment' && current_step != 'pending' && current_step != 'businesstype'
         logger.debug 'Registration is not editable anymore. Cannot access page - current_step = ' + current_step.to_s
+        Airbrake.notify(RuntimeError.new('Registration is not editable, redirected to cannot_edit_path'))
         redirect_to cannot_edit_path and return
       end
 
@@ -184,6 +186,7 @@ module RegistrationsHelper
 
       if !session[:editing] && current_step != 'payment' && current_step != 'pending'
         logger.debug 'Registration is not editable anymore. Cannot access page - current_step = ' + current_step.to_s
+        Airbrake.notify(RuntimeError.new('Registration is not editable, redirected to cannot_edit_path'))
         redirect_to cannot_edit_path
         return
       end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -18,6 +18,8 @@ class Metadata < Ohm::Model
     def init (md_hash)
       md = Metadata.create
       md.update_attributes(md_hash)
+       # Set the route to digital to prevent empty route failure in Java service
+      md.route = 'DIGITAL' unless md.route.present?
       md.save
       md
     end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -245,8 +245,7 @@ class Registration < Ohm::Model
         self.addresses.replace(address_list)
       end
 
-      self.metaData.replace( [Metadata.init(result['metaData'])])
-
+      self.metaData.replace([Metadata.init(result['metaData'])])
 
       unless self.tier == 'LOWER'
         Rails.logger.debug 'Initialise finance details'


### PR DESCRIPTION
To address issues with the metaData route not being set and hence the registration being rejected by the Java services tier, this code adds a default for that property.

Also increased the helpful Airbrake notices to assist future debugging.
