### PR TITLE
Test that Redis is available before each page load

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
-# Default controller for the service, it handles the index (root) page and
-# other pages like version and maintenance
 class HomeController < ApplicationController
+  # Default controller for the service, it handles the index (root) page and
+  # other pages like version and maintenance
 
   def index
     if Rails.application.config.show_developer_index_page


### PR DESCRIPTION
We want to implement the Redis option, `noeviction` which will prevent random data loss in our application. If we do that there is a possibility of Redis becoming full when not manually emptied. When that happens Rails will display a generic 500 error, this PR detects the condition and gives the user a friendly error page, as well as reporting the issue to Errbit.
