### PR TITLE
Fix worldpay refusal redirection

### DIFF
--- a/app/controllers/worldpay_controller.rb
+++ b/app/controllers/worldpay_controller.rb
@@ -53,7 +53,7 @@ class WorldpayController < ApplicationController
       end
 
     else # We get here if 'process_payment' returns false.
-      next_step = upper_payment_path(@registration.reg_uuid)
+      next_step = upper_payment_path(@registration.reg_uuid, order_type: order_type)
     end
 
     redirect_to next_step
@@ -66,7 +66,7 @@ class WorldpayController < ApplicationController
       # Should not get here as payment should have failed and thus return false
     else
       flash[:notice] = I18n.t('registrations.form.paymentFailed')
-      redirect_to upper_payment_path(reg_uuid: @registration.reg_uuid)
+      redirect_to upper_payment_path(reg_uuid: @registration.reg_uuid, order_type: params[:order_type])
     end
   end
 

--- a/app/helpers/worldpay_helper.rb
+++ b/app/helpers/worldpay_helper.rb
@@ -162,7 +162,7 @@ module WorldpayHelper
       end
       flash.now[:notice] = I18n.t('errors.messages.worldpayErrorRedirect')
       flash[:notice] = I18n.t('errors.messages.worldpayErrorRedirect') + errorMessage.to_s
-      redirect_url = upper_payment_path(reg_uuid: registration.reg_uuid)
+      redirect_url = upper_payment_path(reg_uuid: registration.reg_uuid, order_type: order_type)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/CWBsFn1P/128-cancelling-worldpay-payment-for-edit-causes-error

When a card payment is refused, the system should redirect the user back to the payment page. This fixes an error with that redirection process.
