### PR TITLE
Fix WorldPay help errors when registration has no account email

### DIFF
--- a/app/helpers/worldpay_helper.rb
+++ b/app/helpers/worldpay_helper.rb
@@ -19,7 +19,7 @@ module WorldpayHelper
       'registrations.order.wpOrderDescription',
       identifier: registration.regIdentifier.to_s)
     order_content = order.description.encode(xml: :text)
-    shopper_email = CGI.escape(registration.accountEmail) || ''
+    shopper_email = CGI.escape(registration.accountEmail.to_s)
     shopper_first_name = registration.firstName.encode(xml: :text)
     shopper_lastname = registration.lastName.encode(xml: :text)
 


### PR DESCRIPTION
Resolves a small recently-introduced issue which prevents registrations with no account email using WorldPay for Edits or Copy Card orders.  All registrations migrated from IR fall into this category.