### PR TITLE
Allow companies in "voluntary arrangement" status to register

### DIFF
--- a/app/models/companies_house_caller.rb
+++ b/app/models/companies_house_caller.rb
@@ -23,7 +23,7 @@ class CompaniesHouseCaller
 
       company_status = json['company_status']
       Rails.logger.debug 'JSON company status is ' + company_status
-      company_status == 'active' ? :active : :inactive
+      Rails.configuration.waste_exemplar_allowed_company_statuses.include?(company_status) ? :active : :inactive
 
     rescue RestClient::ResourceNotFound
       Rails.logger.debug 'Companies House: resource not found'

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,6 +79,10 @@ module Registrations
     config.waste_exemplar_companies_house_api_url = 'https://api.companieshouse.gov.uk/company/'
     config.waste_exemplar_companies_house_api_key = ENV['WCRS_FRONTEND_COMPANIES_HOUSE_API_KEY']
     config.waste_exemplar_companies_house_url = 'http://www.companieshouse.gov.uk/info'
+    # (The value for this environment variable should be a comma-separated list of allowed
+    # company statuses.  We convert this into a whitespace-free array of strings below)
+    config.waste_exemplar_allowed_company_statuses =
+      (ENV['WCRS_FRONTEND_ALLOWED_COMPANY_STATUSES'] || 'active, voluntary-arrangement').split(/\s*,\s*/)
 
     # In Production we want to verify that requests to agency user and
     # administration functionality have been made via the 'internal' subdomain


### PR DESCRIPTION
Product owner has requested that companies who are in a Voluntary Arrangement status should be allowed to register on the service.  Took the opportunity to make the list of allowable statuses configurable via an Environment Variable (optional) so we can change this without a deployment in the future.