### PR TITLE
Resolve two "pending" steps in the Cucumber suite

### DIFF
--- a/features/session_timeout.feature
+++ b/features/session_timeout.feature
@@ -19,15 +19,14 @@ Feature: Session timeout
   in application.rb.
 
 Scenario: Waste carrier registration does not expire due to inactivity
-  Given I have started my registration
+  Given I have started a new registration and gone as far as the Waste From Other Businesses step
   When I do nothing for more than 20 minutes
-  And I try to proceed with my unfinished registration
-  Then I can still proceed
+  Then I can still continue past the Waste From Other Businesses step
 
 Scenario: Waste carrier registration does not expire due to total session duration
-  Given I have started my registration
+  Given I have started a new registration and gone as far as the Waste From Other Businesses step
   And I keep working on my registration for more than 8 hours
-  Then I can continue with my registration
+  Then I can still continue past the Waste From Other Businesses step
 
 Scenario: Logged in waste carrier session expires due to inactivity
   Given I am logged in as a waste carrier

--- a/features/step_definitions/session_timeout_steps.rb
+++ b/features/step_definitions/session_timeout_steps.rb
@@ -10,29 +10,24 @@ Then(/^I am informed that my session has expired$/) do
   expect(page).to have_text 'Your session has expired'
 end
 
-Given(/^I have started my registration$/) do
-  visit start_path
-  choose 'registration_newOrRenew_renew'
-  click_button 'continue'
+Given('I have started a new registration and gone as far as the Waste From Other Businesses step') do
+  go_to_start_page
+  start_page_select_new
+  business_type_page?
+  business_type_page_select_sole_trader
+  other_businesses_page?
 end
 
-# When(/^I try to proceed with my unfinished registration$/) do
-#   visit business_type_path
-# end
-
-Then(/^I can still proceed$/) do
-  expect(page).to have_text 'What type of business or organisation are you?'
+When('I can still continue past the Waste From Other Businesses step') do
+  other_businesses_page?
+  other_businesses_page_select_yes
+  service_provided_page?
 end
 
 Given(/^I keep working on my registration for more than (\d+) hours$/) do |number_of_hours|
   # Note: We could keep accessing the current page to avoid session inactivity timeouts - but this should not be necessary for WCs
   Timecop.travel(number_of_hours.to_i.hours.from_now + 1.minute)
 end
-
-# Then(/^I can continue with my registration$/) do
-#   visit business_type_path
-#   expect(page).to have_text 'What type of business or organisation are you?'
-# end
 
 Given(/^I am logged in as a waste carrier$/) do
   open_email my_user.email

--- a/features/support/pages/business_type_page.rb
+++ b/features/support/pages/business_type_page.rb
@@ -1,8 +1,8 @@
 # Helper used in testing for working with the business type page.
 module BusinessTypePage
-  
+
   def business_type_page?
-    expect(page).to have_css 'a[data-journey$="business-type"]'
+    expect(page).to have_css 'div[data-journey$="business-type"]'
   end
 
   def business_type_page_select_sole_trader(submit: 'true')

--- a/features/support/pages/construction_demolition_page.rb
+++ b/features/support/pages/construction_demolition_page.rb
@@ -5,7 +5,7 @@ module ConstructionDemolitionPage
   end
 
   def construction_demolition_page?
-    page.expect(page).to have_css 'a[data-journey$="constructiondemolition"]'
+    expect(page).to have_css 'div[data-journey$="constructiondemolition"]'
   end
 
   def construction_demolition_page_select_no(submit: 'true')

--- a/features/support/pages/existing_registration_page.rb
+++ b/features/support/pages/existing_registration_page.rb
@@ -5,7 +5,7 @@ module ExistingRegistrationPage
   end
 
   def existing_registration_page?
-    page.expect(page).to have_css 'a[data-journey$="existing-registration"]'
+    expect(page).to have_css 'div[data-journey$="existing-registration"]'
   end
 
   def existing_registration_page_complete_form(

--- a/features/support/pages/no_registration.rb
+++ b/features/support/pages/no_registration.rb
@@ -5,7 +5,7 @@ module NoRegistrationPage
   end
 
   def no_registration_page?
-    page.expect(page).to have_css 'a[data-journey$="noregistration"]'
+    expect(page).to have_css 'div[data-journey$="noregistration"]'
   end
 end
 World(NoRegistrationPage)

--- a/features/support/pages/only_deal_with_page.rb
+++ b/features/support/pages/only_deal_with_page.rb
@@ -5,7 +5,7 @@ module OnlyDealWithPage
   end
 
   def only_deal_with_page?
-    page.expect(page).to have_css 'a[data-journey$="onlydealwith"]'
+    expect(page).to have_css 'div[data-journey$="onlydealwith"]'
   end
 
   def only_deal_with_page_select_no(submit: 'true')

--- a/features/support/pages/other_businesses_page.rb
+++ b/features/support/pages/other_businesses_page.rb
@@ -5,7 +5,7 @@ module OtherBusinessesPage
   end
 
   def other_businesses_page?
-    page.expect(page).to have_css 'a[data-journey$="otherbusinesses"]'
+    expect(page).to have_css 'div[data-journey$="otherbusinesses"]'
   end
 
   def other_businesses_page_select_no(submit: 'true')

--- a/features/support/pages/postal_address_page.rb
+++ b/features/support/pages/postal_address_page.rb
@@ -5,7 +5,7 @@ module PostalAddressPage
   end
 
   def postal_address_page?
-    expect(page).to have_css 'a[data-journey$="postal-address"]'
+    expect(page).to have_css 'div[data-journey$="postal-address"]'
   end
 
   def postal_address_page_complete_form(

--- a/features/support/pages/registration_type_page.rb
+++ b/features/support/pages/registration_type_page.rb
@@ -5,7 +5,7 @@ module RegistrationTypePage
   end
 
   def registration_type_page?
-    page.expect(page).to have_css 'a[data-journey$="registration-type"]'
+    expect(page).to have_css 'div[data-journey$="registration-type"]'
   end
 
   def registration_type_page_select_carrier_dealer(submit: 'true')

--- a/features/support/pages/service_provided_page.rb
+++ b/features/support/pages/service_provided_page.rb
@@ -5,7 +5,7 @@ module ServiceProvidedPage
   end
 
   def service_provided_page?
-    page.expect(page).to have_css 'a[data-journey$="serviceprovided"]'
+    expect(page).to have_css 'div[data-journey$="serviceprovided"]'
   end
 
   def service_provided_page_select_no(submit: 'true')

--- a/features/support/pages/start_page.rb
+++ b/features/support/pages/start_page.rb
@@ -5,7 +5,7 @@ module StartPage
   end
 
   def start_page?
-    page.expect(page).to have_css 'a[data-journey$="new-or-renew"]'
+    expect(page).to have_css 'div[data-journey$="new-or-renew"]'
   end
 
   def start_page_select_new(submit = true)


### PR DESCRIPTION
Re-instate two Cucumber suite steps that were accidentally left commented-out after the last piece of work, and refactor them to use the Page Objects model.  Also correct some errors in (unused) steps from related Page Object helpers.