### PR TITLE
Add OS address copyright link, page and test

### DIFF
--- a/app/views/business_details/show.html.erb
+++ b/app/views/business_details/show.html.erb
@@ -91,6 +91,22 @@
         </div>
 
         <%= render 'shared/registration_continue_link' %>
+        <br />
+        <br />
+        <br />
+        <hr />
+        <p class="text font-xsmall" id="os-notice">
+          <%=
+            t(
+              "os_notice.text_html",
+              link: link_to(
+                t("os_notice.url_text"),
+                os_places_terms_path,
+                target: "_blank"
+              )
+            )
+          %>
+        </p>
 
       <% end %>
 

--- a/app/views/pages/os_places_terms.html.erb
+++ b/app/views/pages/os_places_terms.html.erb
@@ -1,0 +1,32 @@
+<%= render 'shared/content_for_pages' %>
+
+<div id="wrapper">
+  <main id="content" role="main" class="group">
+
+    <% content_for :page_title, createTitle('.heading_h1') %>
+
+    <header class="text">
+      <h1 class="form-title heading-large" id="groupLabel">
+        <%= t('.heading_h1') %>
+      </h1>
+    </header>
+
+    <p class="text"><%= t(".para1_text").html_safe %></p>
+
+    <p class="text"><%= t('.para2_text') %></p>
+
+    <h2 class="heading-medium"><%= t('.heading_h2') %></h2>
+
+    <ol class="list list-number text">
+      <li><%= t('.list_item1') %></li>
+      <li><%= t('.list_item2') %></li>
+      <li><%= t('.list_item3') %></li>
+    </ol>
+
+    <div class="panel panel-border-wide">
+      <p class="text"><%= t('.para3_text') %></p>
+      <p class="text"><%= t('.para4_text') %></p>
+    </div>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1662,7 +1662,31 @@ en:
       subtitle: "Summary"
       title: "Summary"
       use_your_information_link: "How we use your personal information"
+  os_notice:
+    text_html: |-
+          &copy; Crown copyright and database rights 2016 Ordnance Survey 100024198. Use of this addressing data is subject to the %{link}.
+    url_text: terms and conditions
   pages:
+    os_places_terms:
+      heading_h1: Ordnance Survey terms and conditions
+      heading_h2: Terms and conditions
+      list_item1: |-
+        You are granted a non-exclusive, royalty free revocable licence solely to view the licensed mapping and addressing data for
+        non-commercial purposes for the period during which we make it available.
+      list_item2: You are not permitted to copy, sub-license, distribute, sell or otherwise make available such data to third parties in any form.
+      list_item3: Third party rights to enforce the terms of this licence shall be reserved to OS.
+      para1_text: |-
+        Addressing information and mapping data from Ordnance Survey (OS) is &copy; Crown copyright and database rights 2016 OS 100024198.
+      para2_text: |-
+        Use of this data is subject to the following conditions by way of exception to the standard Open Government Licence (OGL) referred
+        to at the foot of this page.
+      para3_text: |-
+        22 December 2016: Please note that addressing information and mapping data available from this web service was previously inadvertently
+        released without passing on these terms and conditions.
+      para4_text: |-
+        The previous reference to the OGL without these additional terms was an omission, and you should note that you are only permitted
+        to use such information for viewing for non-commercial purposes; you are not permitted to copy, sub-license, distribute, sell or
+        otherwise make available such data, or use it for any other purpose.
     account_confirmed:
       title: 'Email address confirmed'
       paragraph1: 'Thank you for confirming your email address.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Registrations::Application.routes.draw do
   get "user/:id/registrations" => 'registrations#userRegistrations', as: :user_registrations
 
   # Static pages controller
+  get '/os_places_terms' => 'pages#os_places_terms'
   get '/account_confirmed' => 'pages#account_confirmed'
   get '/password_changed'  => 'pages#mid_registration_password_changed', as: :mid_registration_password_changed
 

--- a/features/lower_tier_registration_form.feature
+++ b/features/lower_tier_registration_form.feature
@@ -18,6 +18,9 @@ Feature: Lower tier
     When I confirm account creation via email
     Then I am registered as a lower tier waste carrier
 
+  Scenario: OS Places copyright message is displayed
+    Then I see the OS places copyright message
+
   Scenario: Autocomplete with unrecognised postcode
     Given I want my business address autocompleted but I provide an unrecognised postcode
     When I try to select an address

--- a/features/step_definitions/lower_tier_registration_steps.rb
+++ b/features/step_definitions/lower_tier_registration_steps.rb
@@ -52,6 +52,10 @@ Given(/^I autocomplete my business address$/) do
   click_button 'continue'
 end
 
+Then(/^I see the OS places copyright message$/) do
+  expect(page).to have_text 'Crown copyright and database rights 2016 Ordnance Survey 100024198'
+end
+
 Given(/^I want my business address autocompleted but I provide an unrecognised postcode$/) do
   fill_in 'sPostcode', with: my_unrecognised_postcode
 end


### PR DESCRIPTION
It's been highlighted that the service is missing a required notice and link to T&C's related to using OS Places and its data within the service.

Specifically we have to add the notice and link on the page where postcode lookup is used. This changes updates the view with the notice text, and adds a new OS Places T&C's page which is accessed from a link in the notice.

See also: https://github.com/EnvironmentAgency/flood-risk-engine/pull/249

![image](https://cloud.githubusercontent.com/assets/1773614/21316423/8cab102a-c5f8-11e6-9b6e-8192fe40fd6d.png)

![image](https://cloud.githubusercontent.com/assets/1773614/21316441/aa0d16ae-c5f8-11e6-8ffa-d5a316be372d.png)
