### PR TITLE
Fix wrong use of country code from countries gem

### DIFF
--- a/app/helpers/worldpay_helper.rb
+++ b/app/helpers/worldpay_helper.rb
@@ -83,7 +83,7 @@ module WorldpayHelper
     # Worldpay will fail if we have no code hence we default to GB if no match
     # was found.
     country = ISO3166::Country.find_country_by_name(address.country)
-    result[:country_code] = country.nil? ? 'GB' : country.gec
+    result[:country_code] = country.nil? ? 'GB' : country.alpha2
 
     result
   end

--- a/spec/helpers/worldpay_helper_spec.rb
+++ b/spec/helpers/worldpay_helper_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe WorldpayHelper do
+  describe '#worldpay_address' do
+    let(:address) do
+      address = build(:address)
+      address.houseNumber = '29'
+      address.addressLine1 = 'Acacia Road'
+      address.addressLine2 = ''
+      address.addressLine3 = ''
+      address.addressLine4 = ''
+      address.townCity = 'Nuttytown'
+      address.postcode = 'BN4 1MN'
+      address.country = 'United Kingdom'
+      address
+    end
+
+    context "when passed an address where the house number isn't blank" do
+      it 'returns a hash containing valid Worldpay keys and values' do
+        expect(helper.worldpay_address(address)).to eq(
+          line_1: '29',
+          line_2: 'Acacia Road',
+          town_city: 'Nuttytown',
+          postcode: 'BN4 1MN',
+          country_code: 'GB'
+        )
+      end
+    end
+
+    context 'when passed an address where the house number is blank' do
+      it 'returns a hash containing valid Worldpay keys and values' do
+        address.houseNumber = nil
+        expect(helper.worldpay_address(address)).to eq(
+          line_1: 'Acacia Road',
+          line_2: '',
+          town_city: 'Nuttytown',
+          postcode: 'BN4 1MN',
+          country_code: 'GB'
+        )
+      end
+    end
+
+    context 'when passed an address without a country' do
+      it "defaults the country code to 'GB' in the returned hash" do
+        address.country = nil
+        expect(helper.worldpay_address(address)[:country_code]).to eq('GB')
+      end
+    end
+
+    context 'when passed an address with a recognised country' do
+      it 'sets the country code correctly in the returned hash' do
+        address.country = 'Slovakia'
+        expect(helper.worldpay_address(address)[:country_code]).to eq('SK')
+      end
+    end
+
+    context 'when passed an address with a unrecognised country' do
+      it "defaults the country code to 'GB' in the returned hash" do
+        address.country = 'Wakanda'
+        expect(helper.worldpay_address(address)[:country_code]).to eq('GB')
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-140

This relates to a call that was logged with our ESG team (ESG38945). The issue reported was that attempts to access Worldpay to pay for a registration would fail for some users.

Specifically the error being returned by Worldpay was `Invalid address: country code 'LO' is not a valid ISO-3166 country code.` After some research we identified **LO** is the code for Slovakia, so assume a user had entered there address and specifed the country as Slovakia.

The country code is a required field when dealing with worldpay; we have to include one in the XML we pass across when redirecting to it.

After some investigation though we spotted the problem is our incorrect usage of the countries gem. We should be calling `country.alpha2` to get the official ISO3166 code (SK). We were calling `country.gec` which returns **LO**.

GEC refers to the U.S. Standard GEC (Global Embargoed Countries) list, whose codes actually differ in some cases hence we are causing worldpay to error by using it.