### PR TITLE
Fix broken comp. house strike off test

### DIFF
--- a/spec/models/companies_house_caller_spec.rb
+++ b/spec/models/companies_house_caller_spec.rb
@@ -118,7 +118,7 @@ describe CompaniesHouseCaller do
     # the first test in each pair below will fail in the medium term (hence using
     # a long-term recording in the second example).
     context 'proposal to strike off' do
-      subject { CompaniesHouseCaller.new '01558706' }
+      subject { CompaniesHouseCaller.new '10761329' }
 
       it 'live response from Companies House (will fail when company changes status)', :vcr do
         subject.status.should == :active


### PR DESCRIPTION
When running the rspec suite we started getting a couple of failing tests. This is because the company referred to in `companies_house_caller_spec.rb` to test receiving a response that has the sub-status of 'proposal to strike off' is now no longer active.

As the VCR cassettes are now no longer committed to source control (a decision made in 2015 89d06d51417fd18fdfb14b9de0836659c02e0c2f) this means they are generated either when cloning the project for the first time, or updated once a year. As such with the change in status of the previous company used it meant the cassette generated now does not match the expectations of the test.

The only fix was to find another company and update the registration number used in the test.