### PR TITLE
Add VCR cassettes to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ capybara-*.html
 /public/maintenance.html
 /coverage/
 /spec/tmp/*
-/spec/vcr/**/*.yml
 *.orig
 rerun.txt
 pickle-email-*.html

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,12 +4,19 @@ VCR.configure do |c|
   c.ignore_request do |req|
     URI(req.uri).port == URI(Rails.configuration.waste_exemplar_elasticsearch_url).port
   end
+
+  # Strip out authorization info
+  c.filter_sensitive_data("Basic <COMPANIES_HOUSE_API_KEY>") do |interaction|
+    if interaction.request.headers["Authorization"].present?
+      interaction.request.headers["Authorization"].first
+    end
+  end
 end
 
 RSpec.configure do |c|
   c.treat_symbols_as_metadata_keys_with_true_values = true
   c.around(:each, :vcr) do |example|
     name = example.metadata[:full_description].split(/\s+/, 2).join("/").underscore.gsub(/[^\w\/]+/, "_")
-    VCR.use_cassette(name, re_record_interval: 6.days) { example.call }
+    VCR.use_cassette(name) { example.call }
   end
 end

--- a/spec/vcr/companies_house_caller_status/active_industrial_and_provident_company_5_digits_with_trailing_r_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_industrial_and_provident_company_5_digits_with_trailing_r_is_active.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/IP27406R
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '739'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '584'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"company_name":"UPPER WENSLEYDALE INDUSTRIAL AND PROVIDENT SOCIETY
+        LIMITED","type":"industrial-and-provident-society","company_number":"IP27406R","jurisdiction":"england-wales","has_been_liquidated":false,"undeliverable_registered_office_address":false,"etag":"da4c1491f5f591ef41c24bba57bb0806ea2c4417","company_status":"active","has_insolvency_history":false,"has_charges":false,"registered_office_address":{"address_line_1":"","locality":"","postal_code":"","address_line_2":""},"accounts":{"accounting_reference_date":{"month":"99","day":"99"},"last_accounts":{"type":"null"}},"links":{"self":"/company/IP27406R"},"partial_data_available":"full-data-available-from-financial-conduct-authority-mutuals-public-register","can_file":false}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_industrial_and_provident_company_6_digits_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_industrial_and_provident_company_6_digits_is_active.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/IP031977
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '672'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '587'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"company_name":"ENERGISE STUR VALLEY INDUSTRIAL AND PROVIDENT SOCIETY
+        LIMITED","has_been_liquidated":false,"undeliverable_registered_office_address":false,"type":"industrial-and-provident-society","company_number":"IP031977","jurisdiction":"england-wales","etag":"9c5773301b80b237e084f71a5766c14c1cbc77eb","company_status":"active","has_charges":false,"has_insolvency_history":false,"accounts":{"last_accounts":{"type":"null"},"accounting_reference_date":{"day":"99","month":"99"}},"links":{"self":"/company/IP031977"},"partial_data_available":"full-data-available-from-financial-conduct-authority-mutuals-public-register","registered_office_address":{},"can_file":false}'
+    http_version:
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_llp_england/wales_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_llp_england/wales_is_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/OC379171
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1283'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '593'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"date_of_creation":"2012-10-10","type":"llp","jurisdiction":"england-wales","company_name":"OC
+        LAW LLP","registered_office_address":{"region":"South Yorkshire","locality":"Sheffield","postal_code":"S9
+        1TP","address_line_2":"250 Shepcote Lane","address_line_1":"Pm House"},"company_number":"OC379171","has_been_liquidated":false,"status":"active","accounts":{"next_accounts":{"period_end_on":"2018-03-31","due_on":"2018-12-31","period_start_on":"2017-04-01","overdue":false},"last_accounts":{"period_start_on":"2016-04-01","made_up_to":"2017-03-31","period_end_on":"2017-03-31"},"next_made_up_to":"2018-03-31","overdue":false,"next_due":"2018-12-31","accounting_reference_date":{"month":"03","day":"31"}},"undeliverable_registered_office_address":false,"has_insolvency_history":false,"etag":"0b34e1fe2a1d437fb652baffa96974f9f08a874c","company_status":"active","has_charges":false,"confirmation_statement":{"next_due":"2018-10-24","last_made_up_to":"2017-10-10","overdue":false,"next_made_up_to":"2018-10-10"},"links":{"self":"/company/OC379171","filing_history":"/company/OC379171/filing-history","officers":"/company/OC379171/officers","persons_with_significant_control":"/company/OC379171/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":false}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_llp_northern_ireland_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_llp_northern_ireland_is_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/NC000059
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1339'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '592'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"accounts":{"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"made_up_to":"2016-12-31","period_end_on":"2016-12-31","type":"micro-entity","period_start_on":"2016-01-01"},"overdue":false,"next_accounts":{"period_end_on":"2017-12-31","overdue":false,"due_on":"2018-09-30","period_start_on":"2017-01-01"},"next_due":"2018-09-30","next_made_up_to":"2017-12-31"},"company_name":"PROTEC
+        (NI) LLP","has_been_liquidated":false,"undeliverable_registered_office_address":false,"registered_office_address":{"address_line_1":"6
+        Trench Road","address_line_2":"Hyde Park Industrial Estate","region":"Co Antrim","locality":"Newtownabbey"},"company_number":"NC000059","date_of_creation":"2005-10-31","type":"llp","jurisdiction":"northern-ireland","has_insolvency_history":false,"etag":"bd3fcefdff0429deb46ee3b62660ff1404b44891","company_status":"active","has_charges":false,"confirmation_statement":{"next_made_up_to":"2017-10-31","overdue":true,"last_made_up_to":"2016-10-31","next_due":"2017-11-14"},"links":{"self":"/company/NC000059","filing_history":"/company/NC000059/filing-history","officers":"/company/NC000059/officers","persons_with_significant_control":"/company/NC000059/persons-with-significant-control"},"registered_office_is_in_dispute":false,"company_status_detail":"active-proposal-to-strike-off","can_file":false}'
+    http_version:
+  recorded_at: Tue, 06 Feb 2018 14:28:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_llp_scotland_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_llp_scotland_is_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/SO302113
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1267'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '590'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"registered_office_address":{"postal_code":"EH1 2BB","address_line_1":"19
+        Rutland Square","locality":"Edinburgh"},"company_number":"SO302113","date_of_creation":"2008-10-30","jurisdiction":"scotland","type":"llp","undeliverable_registered_office_address":false,"company_name":"KLG
+        SCOTLAND LLP","has_been_liquidated":false,"status":"active","accounts":{"overdue":false,"next_made_up_to":"2018-03-31","next_accounts":{"period_end_on":"2018-03-31","overdue":false,"period_start_on":"2017-04-01","due_on":"2018-12-31"},"next_due":"2018-12-31","last_accounts":{"made_up_to":"2017-03-31","period_start_on":"2016-04-01","period_end_on":"2017-03-31"},"accounting_reference_date":{"day":"31","month":"03"}},"has_insolvency_history":false,"etag":"279e7d355dad6617362011792d7e9c084d16692c","has_charges":true,"company_status":"active","confirmation_statement":{"next_due":"2018-11-13","overdue":false,"last_made_up_to":"2017-10-30","next_made_up_to":"2018-10-30"},"links":{"self":"/company/SO302113","filing_history":"/company/SO302113/filing-history","officers":"/company/SO302113/officers","charges":"/company/SO302113/charges","persons_with_significant_control":"/company/SO302113/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":false}'
+    http_version:
+  recorded_at: Tue, 06 Feb 2018 14:28:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_plc_england/wales_8_digits_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_plc_england/wales_8_digits_is_active.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/02050399
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1601'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '589'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"company_number":"02050399","accounts":{"accounting_reference_date":{"month":"03","day":"31"},"next_due":"2018-12-31","next_made_up_to":"2018-03-31","overdue":false,"last_accounts":{"period_start_on":"2016-04-01","made_up_to":"2017-03-31","type":"micro-entity","period_end_on":"2017-03-31"},"next_accounts":{"period_end_on":"2018-03-31","overdue":false,"period_start_on":"2017-04-01","due_on":"2018-12-31"}},"jurisdiction":"england-wales","registered_office_address":{"region":"Mid
+        Glamorgan","locality":"Caerphilly","postal_code":"CF83 1BR","address_line_1":"15
+        Lon Uchaf Lon Uchaf"},"last_full_members_list_date":"2015-12-31","date_of_creation":"1986-08-28","type":"ltd","has_been_liquidated":false,"company_name":"ZENITH
+        PRINT (UK) LIMITED","sic_codes":["70100"],"undeliverable_registered_office_address":false,"has_insolvency_history":false,"etag":"9c6b544fbd0427cdfbb53e0870ca8fa32c084470","company_status":"active","has_charges":true,"previous_company_names":[{"ceased_on":"1996-03-22","effective_from":"1993-04-22","name":"ZENITH
+        TREFOREST PRESS LIMITED"},{"name":"ZENITH COLOUR PRINTING LIMITED","ceased_on":"1993-04-22","effective_from":"1986-11-14"},{"effective_from":"1986-08-28","ceased_on":"1986-11-14","name":"CHANCETACKLE
+        LIMITED"}],"confirmation_statement":{"last_made_up_to":"2017-12-31","next_made_up_to":"2018-12-31","overdue":false,"next_due":"2019-01-14"},"links":{"self":"/company/02050399","filing_history":"/company/02050399/filing-history","officers":"/company/02050399/officers","charges":"/company/02050399/charges"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_plc_northern_ireland_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_plc_northern_ireland_is_active.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/NI063992
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1546'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '585'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"has_been_liquidated":false,"last_full_members_list_date":"2016-06-01","jurisdiction":"northern-ireland","company_name":"AMEY
+        ROADS NI FINANCIAL PLC","sic_codes":["82990"],"status":"active","registered_office_address":{"locality":"Belfast","address_line_1":"Murray
+        House","postal_code":"BT1 6DN","address_line_2":"Murray Street","care_of":"CARSON
+        MCDOWELL LLP"},"type":"plc","company_number":"NI063992","accounts":{"next_due":"2018-09-30","last_accounts":{"made_up_to":"2017-03-31","period_start_on":"2016-04-01","period_end_on":"2017-03-31","type":"full"},"next_accounts":{"overdue":false,"due_on":"2018-09-30","period_start_on":"2017-04-01","period_end_on":"2018-03-31"},"accounting_reference_date":{"month":"03","day":"31"},"overdue":false,"next_made_up_to":"2018-03-31"},"date_of_creation":"2007-04-04","undeliverable_registered_office_address":false,"has_insolvency_history":false,"etag":"2b612dfa19e53d8d345da9a27625313a2552c7a0","company_status":"active","has_charges":true,"previous_company_names":[{"effective_from":"2007-04-04","ceased_on":"2014-12-12","name":"AMEY
+        LAGAN ROADS FINANCIAL PLC"}],"confirmation_statement":{"next_due":"2018-06-15","next_made_up_to":"2018-06-01","last_made_up_to":"2017-06-01","overdue":false},"links":{"self":"/company/NI063992","filing_history":"/company/NI063992/filing-history","officers":"/company/NI063992/officers","charges":"/company/NI063992/charges","persons_with_significant_control":"/company/NI063992/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/active_plc_scotland_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/active_plc_scotland_is_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/SC028747
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1320'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '586'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"type":"ltd","registered_office_address":{"address_line_1":"34 Old
+        Mill Road","postal_code":"G71 7HH","address_line_2":"Uddingston"},"company_number":"SC028747","company_name":"THOMAS
+        TUNNOCK LIMITED","undeliverable_registered_office_address":false,"accounts":{"overdue":false,"last_accounts":{"period_start_on":"2016-03-01","period_end_on":"2017-02-25","made_up_to":"2017-02-25","type":"full"},"accounting_reference_date":{"day":"28","month":"02"},"next_due":"2018-11-30","next_made_up_to":"2018-02-28","next_accounts":{"period_start_on":"2017-02-26","period_end_on":"2018-02-28","overdue":false,"due_on":"2018-11-30"}},"jurisdiction":"scotland","sic_codes":["32990"],"last_full_members_list_date":"2016-05-09","has_been_liquidated":false,"status":"active","date_of_creation":"1952-02-16","has_insolvency_history":false,"etag":"f908f3e2de41f774cbb61d9c11732720bda14226","has_charges":false,"company_status":"active","confirmation_statement":{"overdue":false,"next_due":"2018-05-23","next_made_up_to":"2018-05-09","last_made_up_to":"2017-05-09"},"links":{"self":"/company/SC028747","filing_history":"/company/SC028747/filing-history","officers":"/company/SC028747/officers","persons_with_significant_control":"/company/SC028747/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/another_active_company_plc_england/wales_6_digits_with_leading_zeros_omitted_is_active.yml
+++ b/spec/vcr/companies_house_caller_status/another_active_company_plc_england/wales_6_digits_with_leading_zeros_omitted_is_active.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/00445790
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1451'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '588'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"accounts":{"overdue":false,"last_accounts":{"type":"group","period_end_on":"2017-02-25","made_up_to":"2017-02-25","period_start_on":"2016-02-28"},"next_accounts":{"period_end_on":"2018-02-26","due_on":"2018-08-26","period_start_on":"2017-02-26","overdue":false},"accounting_reference_date":{"month":"02","day":"26"},"next_due":"2018-08-26","next_made_up_to":"2018-02-26"},"company_name":"TESCO
+        PLC","undeliverable_registered_office_address":false,"type":"plc","sic_codes":["47110"],"registered_office_address":{"country":"United
+        Kingdom","address_line_2":"Kestrel Way","locality":"Welwyn Garden City","address_line_1":"Tesco
+        House, Shire Park","postal_code":"AL7 1GA"},"jurisdiction":"england-wales","company_number":"00445790","has_been_liquidated":false,"date_of_creation":"1947-11-27","last_full_members_list_date":"2013-06-07","company_status":"active","etag":"ca5769f09c104a0cd5997dcf7c1912aa1f3fe7b5","has_charges":true,"has_insolvency_history":false,"previous_company_names":[{"effective_from":"1947-11-27","ceased_on":"1983-08-25","name":"TESCO
+        STORES (HOLDINGS) PUBLIC LIMITED COMPANY"}],"confirmation_statement":{"last_made_up_to":"2017-06-07","next_made_up_to":"2018-06-07","next_due":"2018-06-21","overdue":false},"links":{"self":"/company/00445790","filing_history":"/company/00445790/filing-history","officers":"/company/00445790/officers","charges":"/company/00445790/charges"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/not_active_is_not_active.yml
+++ b/spec/vcr/companies_house_caller_status/not_active_is_not_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/05868270
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '969'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '583'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"has_been_liquidated":true,"last_full_members_list_date":"2013-07-06","date_of_creation":"2006-07-06","type":"ltd","sic_codes":["62012","63110","63120"],"jurisdiction":"england-wales","company_name":"BEEF
+        LTD","registered_office_address":{"address_line_2":"Bath Road","locality":"Bristol","postal_code":"BS4
+        3EH","address_line_1":"Unit 1.10 The Paintworks"},"company_number":"05868270","undeliverable_registered_office_address":false,"accounts":{"accounting_reference_date":{"month":"08","day":"31"},"last_accounts":{"type":"total-exemption-small","made_up_to":"2012-08-31"}},"has_insolvency_history":true,"etag":"d40ffbea6e7243a46b5626710fdfcb29c515cb62","company_status":"dissolved","has_charges":false,"links":{"self":"/company/05868270","filing_history":"/company/05868270/filing-history","officers":"/company/05868270/officers","insolvency":"/company/05868270/insolvency"},"registered_office_is_in_dispute":false,"date_of_cessation":"2016-12-13","can_file":false}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/not_found_is_not_found.yml
+++ b/spec/vcr/companies_house_caller_status/not_found_is_not_found.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '70'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '591'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/proposal_to_strike_off_live_response_from_companies_house_will_fail_when_company_changes_status_.yml
+++ b/spec/vcr/companies_house_caller_status/proposal_to_strike_off_live_response_from_companies_house_will_fail_when_company_changes_status_.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/10761329
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1198'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '594'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"registered_office_is_in_dispute":false,"has_charges":false,"undeliverable_registered_office_address":false,"type":"ltd","company_status":"active","links":{"self":"/company/10761329","persons_with_significant_control":"/company/10761329/persons-with-significant-control","filing_history":"/company/10761329/filing-history","officers":"/company/10761329/officers"},"has_insolvency_history":false,"company_number":"10761329","company_name":"WASTE
+        AWAY SERVICES LTD","confirmation_statement":{"next_due":"2018-05-22","overdue":false,"next_made_up_to":"2018-05-08"},"accounts":{"next_due":"2019-02-09","accounting_reference_date":{"month":"05","day":"31"},"next_accounts":{"due_on":"2019-02-09","period_start_on":"2017-05-09","overdue":false,"period_end_on":"2018-05-31"},"last_accounts":{"type":"null"},"next_made_up_to":"2018-05-31","overdue":false},"sic_codes":["96090"],"registered_office_address":{"locality":"Hoddesdon","country":"United
+        Kingdom","address_line_1":"72 Old Essex Road","postal_code":"EN11 0AE"},"etag":"395a26e068aad0ceab8d335a43e6452b6d4b4726","jurisdiction":"england-wales","date_of_creation":"2017-05-09","company_status_detail":"active-proposal-to-strike-off","can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/companies_house_caller_status/voluntary_arrangement_live_response_from_companies_house_will_fail_when_company_changes_status_.yml
+++ b/spec/vcr/companies_house_caller_status/voluntary_arrangement_live_response_from_companies_house_will_fail_when_company_changes_status_.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/04270505
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1655'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '595'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"registered_office_address":{"postal_code":"SR8 2HY","locality":"Peterlee","address_line_2":"North
+        West Industrial Estate","address_line_1":"2 Cook Way","region":"Co Durham"},"has_been_liquidated":false,"accounts":{"next_made_up_to":"2018-03-31","next_accounts":{"overdue":false,"period_end_on":"2018-03-31","period_start_on":"2017-04-01","due_on":"2018-12-31"},"overdue":false,"next_due":"2018-12-31","accounting_reference_date":{"month":"03","day":"31"},"last_accounts":{"period_end_on":"2017-03-31","made_up_to":"2017-03-31","period_start_on":"2016-04-01","type":"full"}},"jurisdiction":"england-wales","company_name":"TSF
+        RETAIL SOLUTIONS LIMITED","type":"ltd","last_full_members_list_date":"2015-08-15","sic_codes":["43320","43390","43999"],"date_of_creation":"2001-08-15","company_number":"04270505","undeliverable_registered_office_address":false,"has_insolvency_history":true,"etag":"a47700a2d099085f5f6096387d0b5ef584bc269b","company_status":"active","has_charges":true,"previous_company_names":[{"effective_from":"2001-11-01","ceased_on":"2006-06-01","name":"MOMS
+        LIMITED"},{"name":"BLAZECLEAN LIMITED","effective_from":"2001-08-15","ceased_on":"2001-11-01"}],"confirmation_statement":{"last_made_up_to":"2017-08-15","next_made_up_to":"2018-08-15","next_due":"2018-08-29","overdue":false},"links":{"self":"/company/04270505","filing_history":"/company/04270505/filing-history","officers":"/company/04270505/officers","charges":"/company/04270505/charges","insolvency":"/company/04270505/insolvency","persons_with_significant_control":"/company/04270505/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:28:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_doesnt_match_against_a_conviction_record_with_a_dob.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_doesnt_match_against_a_conviction_record_with_a_dob.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Blogs&companyNumber=99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF3NQQqDMBQE0Lv8tYtGlEoOUY8Q0jjaQPKFn7gQ6d0rKYq4
+        fcPMbCQYIWAH0ryEUJGbefQSMZAmnqmiaLP7GEFaQt7t1R/meTJpTRnx6BbG
+        YNjGcy/BSkG7t1WrukfzrJu6VeryVcLbv3mvf/v+AALpkB6mAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_will_find_a_match_ignoring_common_terms.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_will_find_a_match_ignoring_common_terms.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Recycle-pro&companyNumber=99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OPQvCMBCA4b9SblKoYEuK4u6kU6uDU4jpVQP5kEs6BPG/
+        e1YKHe+54+XeQDggodcIB4ASdPCDIYc9jz4wOJX0UxLG0Sa227Gb0fiHjDkm
+        dOxtd5kde+mV+/Va1Flb3LwoFKvraV2cjTOJ2yVEVDSdKq5WTbXfil0tatGI
+        xQ/T0o/WLu2e//b5AuHEX5u8AAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_will_find_a_word_match_ignoring_puctuation.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_will_find_a_word_match_ignoring_puctuation.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Recycle%20pro%20UK%20Limited&companyNumber=99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OwQrCMAyA4VcZOSlMsGNO8e5JT5sePI3aZa7QptJ2hyK+
+        u3Ey2DFfwk/e4LFHj6QQjgA5KEe99hY7HskxWBnV0HoMo4ls91Mzo6ZnG1KI
+        aNnr5jo7di1J++vVqJIyuHl5l61u53V20VZHbucQUPrpVHJV7MRhW+6LsqhE
+        tfhhWtJozNIe6W+fLxVmM5G8AAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_will_find_an_exact_match.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_will_find_an_exact_match.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Test%20Waste%20Services%20Ltd.&companyNumber=99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OQQvCMAyG4b9SehZxc67TuzcP6gTxVGqb6aDNIO2EIf53
+        42Sw65OXj7wlQQMEaEHupFJlKRfSdti0FMAxYccQTLJPTRB7n9hu+3rCFh86
+        DjFBYD+ezpOD02jCb/MCMYmr4UTUQK/WQhSH5JZcRjA0poZXs01WrQqVF/l6
+        W81+GI/Yez+3+/C3zxd4NXw1wAAAAA==
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_works_when_company_number_is_omitted.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_name_works_when_company_number_is_omitted.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Test%20Waste%20Services%20Ltd.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OQQvCMAyG4b9SehZxY2vFuzcP6gTxVGqb6aDNoOmEIf53
+        42Sw65OXj7xlghYSoAO5k1orJVfS9dh2KYJnwp4h2uyeJgENIbPd9s2MHT4M
+        jZQhsh9P59nBG7Txt3kByuJqORENpFfngMQh+zWXBDZNqeXVoi62m0qXVVkr
+        vfhhOuIQwtLu498+XzB5X0rAAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_doesnt_match_when_it_shouldnt.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_doesnt_match_when_it_shouldnt.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Wrong%20company%20name&companyNumber=99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF3NQQqDMBQE0Lv8tQsjiqmHqEcIaRxbIfnCT1yI9O5KRCnd
+        vmFmNhKMELADdbx4X5CbeZwkYKCOeKaCgk3uYwRx8emwZ3/ZxG8T15gQrm5m
+        DIZtuPcirGS0R1s1Spd1W9WVbh4/Xzn8+zev9bTvDqMcjdimAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_whitespace_does_not_affect_the_result.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_whitespace_does_not_affect_the_result.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Wrong%20company%20name&companyNumber=00009876
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OPQvCMBCA4b9SblKo0Jb6uTvp1OrgFGJ61UBykSQdgvjf
+        PSuFjvfc8XJv8NijR1IIB4AclKNee4sdj+QYrIzqKTyGwUS227GdUNNDhBQi
+        WvamvUyOnSBpf70GVVIGVy/vssX1tMzO2urI7RwCSj+eSq6W63JX1NuqrvbF
+        ZvbDuKTBmLnd098+X5H8yIq8AAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_company_number_with_leading_zeros_1.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_company_number_with_leading_zeros_1.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Wrong%20company%20name&companyNumber=00654321
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OMQuDMBAF4L8SMisYm6J071ToUorVJaTxbIXkAkkcpPS/
+        97QIbsf3Ho/78AADBEAD/MS7XB5KkReCZ9x4HMbgoCdHT+B0Mm8VIE42kbXn
+        24YjvlScYwJH/mi7zaFXqN0y3GhK2dUn1mhMy5Gx+4V6EXRYi5o2xVHUhaxK
+        WVa13H2whjhZu7fn/LfvD4qEnnfDAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_company_number_with_leading_zeros_2.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_company_number_with_leading_zeros_2.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Wrong%20company%20name&companyNumber=00009876
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OwQrCMAyA4VcZPSlMsGXi8O5JT5sePI3aZVpoU0m7QxHf
+        3TgZ7Jgv4SdvQTAAARoQByFKYQIOljz0PGJg8DqZZ0cQR5fYbsd2RouPLuaY
+        wLM37WV26DvU/tdrwGTjYPOiUKyup3Vxtt4mbpcigqbpVHNV7mS9rfaqUrWS
+        ix+mJY7OLe2e//b5Ag27if+8AAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_company_number_with_leading_zeros_3.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_company_number_with_leading_zeros_3.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Wrong%20company%20name&companyNumber=00009876
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OwQrCMAyA4VcZOSlM2Mpk4t3TPG168DRql2mhTaXtDkV8
+        d+NksGO+hJ+8weOIHkkhHAFyUI5G7S0OPJJjsDKqZ+8xTCay3U7dgpoefUgh
+        omVvu8viOPQk7a/XokrK4O7lXba5NtvsrK2O3M4hoPTzqeRquS8PRVWLStSi
+        WP0wL2kyZm339LfPF5xTWAK8AAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_on_company_number_when_possible.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_will_match_on_company_number_when_possible.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyName=Wrong%20company%20name&companyNumber=12345678
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OQQvCMAyG4b8yehZxY7bDuzcP6gTxVGqbaaHtIOmEIf53
+        42Sw65OXj7wFQgcIyYLYCaWkFCth+9R5jOCYUs8QTbZPjUBDyGy3fTujTw9N
+        I2WI7MfTeXZwOpn427wA5eJqOClawJe3QMUhuzWXBAan1PBquS2bTa2qupKq
+        WfwwHdMQwtLu498+X9Jh4avAAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_works_when_company_name_is_omitted.yml
+++ b/spec/vcr/conviction_search_result_search_company_convictions/search_with_company_number_works_when_company_name_is_omitted.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/company?companyNumber=12345678
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3OQQvCMAyG4b9SehZxY1vFuzcP6gTxVGqbaaHNoOmEIf53
+        42Sw65OXj7xlgg4SoAW5k0o1jVxJ22PnUwTHhD1DNNk+dQIaQma77dsZPT40
+        jZQhsh9P59nBaTTxt3kByuJqOBEtpJe3QOKQ3ZpLApOm1PBqURfbTaXKqlR1
+        ufhhOuIQwtLu498+X2yPd5/AAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_doesnt_match_against_a_record_with_a_company_number.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_doesnt_match_against_a_record_with_a_company_number.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?firstname=Waste&lastname=Want
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF3NTQqDMBQE4Lu8tQsTFIuHaI8QYhx/IHnCS1xI6d2ViCLd
+        fsPMfEkwQMAO1PLqfUFu4WGWgJ5a4oUKCja5yQji6tNh789lM48mbjEhXN3M
+        6A3bcO9FWMloj7aq1ausGl1prdXjK4d//6bbTvvtIVt8AaYAAAA=
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_doesnt_match_when_it_shouldnt.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_doesnt_match_when_it_shouldnt.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?firstname=Billy&lastname=Bluehat
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF3NQQqDMBQE0Lv8tYtGLEoO0R4hxDi2geQLP3Eh4t0rKYq4
+        fcPMrCQYIWAH0jyHUJGbePQSMZAmnqiiaLP7GkGaQ97t9T7M88ekJWXEo1sY
+        g2Ebz70EKwXt3lZP1T2atm5q1XaXrxLe/k2//G37AYiIi1emAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_matches_on_last_and_first_when_possible.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_matches_on_last_and_first_when_possible.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?firstname=Fred&lastname=Blogs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3NQQrCMBCF4avIrLtoYkRxZ6VewJWrENNpLSQTmKSLIt7d
+        sVLo9nvwvzcw9shIHuEMSu8NVOAT9SNH7IQoCURX/Msy5ikUsUd7X3GkweY5
+        F4zil+a6OnaWXPw1m5CGXO1uLLkKMjpeVichdVCn2hy10bVWm9tlpCmErT3n
+        v32+YhxhV7MAAAA=
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_matches_on_last_name_and_first_initial_when_required.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_matches_on_last_name_and_first_initial_when_required.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?firstname=Jacob&lastname=Blogs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3NsQ6CMBSF4VcxnRloLdE4oji4Ojk1tVyQpL1NbstAjO/u
+        BULC+v3JOV9B0AEBOhAXoY66EoVwEbuBArRMGBmCze5jCNLoM9ureW44YG/S
+        lDIE9vp6a+5bgdagDfNq7WOfisPDInBMYGmplqdkJc+lPimtZCl3x0vE0fu9
+        vafVfn/MXU73tQAAAA==
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_will_match_part_of_a_hypenated_surname.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_and_first_name_will_match_part_of_a_hypenated_surname.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?firstname=Alex&lastname=Brown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:22 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAE3NwQrCMBAE0F+RnBXammjxZrVf0JOnENOtLSQb2KRoEf/d
+        tVLo9c0w8xYEHRCgBXESe6kOYitswG4gDy0TBgZvku01QRxdYrvVzYIDPnSc
+        YgLPfrnWi0Or0fjf5tnBa9P4IfW7isITuRHB0FwxvJarvMzksZBFpsrV9xzi
+        6Nza7tPfPl+xlDRfuAAAAA==
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_name_only_doesnt_match_when_it_shouldnt.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_name_only_doesnt_match_when_it_shouldnt.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?lastname=Bluehat
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:21 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF3NQQqDMBQE0Lv8tQtTIloPUY8QYhxbIfnCT1yI9O6ViEXc
+        vmFmNhKMELADtbx4X5CbeZwkYKCWeKaCgk3uYwRx8Wm3V3faxG8T15gQzm5m
+        DIZt+O9FWMlo97aqVFPq+qHVU+nLVw5v/6ZfD/v+ANsuh0umAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_name_only_doesnt_return_a_match_even_when_the_surname_matches_if_no_first_initial_is_available_to_match_against.yml
+++ b/spec/vcr/conviction_search_result_search_person_convictions/search_with_last_name_only_doesnt_return_a_match_even_when_the_surname_matches_if_no_first_initial_is_available_to_match_against.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9290/convictions/person?lastname=Blogs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 23:47:21 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF3NQQqDMBQE0Lv8tYumWK0eoh4hxDhWIfnCT1yIeHclYpFu
+        3zAzKwl6CNiCap6dy8hO3I/i0VFNPFFG3kQ7aEGYXTzs01w28leHJUT4q5sY
+        nWbjf3sBRhKao61e6v3Iy2euqrK4faXw71+3y2nbDh0RnJumAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 23:47:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/manually_expired/companies_house/proposal_to_strike_off.yml
+++ b/spec/vcr/manually_expired/companies_house/proposal_to_strike_off.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/10761329
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Jan 2018 21:23:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1198'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '580'
+      X-Ratelimit-Reset:
+      - '1516310778'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"registered_office_is_in_dispute":false,"has_charges":false,"undeliverable_registered_office_address":false,"type":"ltd","company_status":"active","links":{"self":"/company/10761329","persons_with_significant_control":"/company/10761329/persons-with-significant-control","filing_history":"/company/10761329/filing-history","officers":"/company/10761329/officers"},"has_insolvency_history":false,"company_number":"10761329","company_name":"WASTE
+        AWAY SERVICES LTD","confirmation_statement":{"next_due":"2018-05-22","overdue":false,"next_made_up_to":"2018-05-08"},"accounts":{"next_due":"2019-02-09","accounting_reference_date":{"month":"05","day":"31"},"next_accounts":{"due_on":"2019-02-09","period_start_on":"2017-05-09","overdue":false,"period_end_on":"2018-05-31"},"last_accounts":{"type":"null"},"next_made_up_to":"2018-05-31","overdue":false},"sic_codes":["96090"],"registered_office_address":{"locality":"Hoddesdon","country":"United
+        Kingdom","address_line_1":"72 Old Essex Road","postal_code":"EN11 0AE"},"etag":"395a26e068aad0ceab8d335a43e6452b6d4b4726","jurisdiction":"england-wales","date_of_creation":"2017-05-09","company_status_detail":"active-proposal-to-strike-off","can_file":true}'
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 21:23:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/manually_expired/companies_house/voluntary_arrangement.yml
+++ b/spec/vcr/manually_expired/companies_house/voluntary_arrangement.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/04270505
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Jan 2018 16:10:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1655'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '598'
+      X-Ratelimit-Reset:
+      - '1516292001'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"registered_office_address":{"postal_code":"SR8 2HY","locality":"Peterlee","address_line_2":"North
+        West Industrial Estate","address_line_1":"2 Cook Way","region":"Co Durham"},"has_been_liquidated":false,"accounts":{"next_made_up_to":"2018-03-31","next_accounts":{"overdue":false,"period_end_on":"2018-03-31","period_start_on":"2017-04-01","due_on":"2018-12-31"},"overdue":false,"next_due":"2018-12-31","accounting_reference_date":{"month":"03","day":"31"},"last_accounts":{"period_end_on":"2017-03-31","made_up_to":"2017-03-31","period_start_on":"2016-04-01","type":"full"}},"jurisdiction":"england-wales","company_name":"TSF
+        RETAIL SOLUTIONS LIMITED","type":"ltd","last_full_members_list_date":"2015-08-15","sic_codes":["43320","43390","43999"],"date_of_creation":"2001-08-15","company_number":"04270505","undeliverable_registered_office_address":false,"has_insolvency_history":true,"etag":"a47700a2d099085f5f6096387d0b5ef584bc269b","company_status":"active","has_charges":true,"previous_company_names":[{"effective_from":"2001-11-01","ceased_on":"2006-06-01","name":"MOMS
+        LIMITED"},{"name":"BLAZECLEAN LIMITED","effective_from":"2001-08-15","ceased_on":"2001-11-01"}],"confirmation_statement":{"last_made_up_to":"2017-08-15","next_made_up_to":"2018-08-15","next_due":"2018-08-29","overdue":false},"links":{"self":"/company/04270505","filing_history":"/company/04270505/filing-history","officers":"/company/04270505/officers","charges":"/company/04270505/charges","insolvency":"/company/04270505/insolvency","persons_with_significant_control":"/company/04270505/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 16:09:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/registration/upper_business_details_step_uk_limited_company_manual_uk_address_behaves_like_a_uk_company_number_step_should_allow_active_company.yml
+++ b/spec/vcr/registration/upper_business_details_step_uk_limited_company_manual_uk_address_behaves_like_a_uk_company_number_step_should_allow_active_company.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/02050399
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1601'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '596'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"company_number":"02050399","accounts":{"accounting_reference_date":{"month":"03","day":"31"},"next_due":"2018-12-31","next_made_up_to":"2018-03-31","overdue":false,"last_accounts":{"period_start_on":"2016-04-01","made_up_to":"2017-03-31","type":"micro-entity","period_end_on":"2017-03-31"},"next_accounts":{"period_end_on":"2018-03-31","overdue":false,"period_start_on":"2017-04-01","due_on":"2018-12-31"}},"jurisdiction":"england-wales","registered_office_address":{"region":"Mid
+        Glamorgan","locality":"Caerphilly","postal_code":"CF83 1BR","address_line_1":"15
+        Lon Uchaf Lon Uchaf"},"last_full_members_list_date":"2015-12-31","date_of_creation":"1986-08-28","type":"ltd","has_been_liquidated":false,"company_name":"ZENITH
+        PRINT (UK) LIMITED","sic_codes":["70100"],"undeliverable_registered_office_address":false,"has_insolvency_history":false,"etag":"9c6b544fbd0427cdfbb53e0870ca8fa32c084470","company_status":"active","has_charges":true,"previous_company_names":[{"ceased_on":"1996-03-22","effective_from":"1993-04-22","name":"ZENITH
+        TREFOREST PRESS LIMITED"},{"name":"ZENITH COLOUR PRINTING LIMITED","ceased_on":"1993-04-22","effective_from":"1986-11-14"},{"effective_from":"1986-08-28","ceased_on":"1986-11-14","name":"CHANCETACKLE
+        LIMITED"}],"confirmation_statement":{"last_made_up_to":"2017-12-31","next_made_up_to":"2018-12-31","overdue":false,"next_due":"2019-01-14"},"links":{"self":"/company/02050399","filing_history":"/company/02050399/filing-history","officers":"/company/02050399/officers","charges":"/company/02050399/charges"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:27:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/registration/upper_business_details_step_uk_limited_company_manual_uk_address_behaves_like_a_uk_company_number_step_should_not_allow_company_which_is_not_active.yml
+++ b/spec/vcr/registration/upper_business_details_step_uk_limited_company_manual_uk_address_behaves_like_a_uk_company_number_step_should_not_allow_company_which_is_not_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/05868270
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '969'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '597'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"has_been_liquidated":true,"last_full_members_list_date":"2013-07-06","date_of_creation":"2006-07-06","type":"ltd","sic_codes":["62012","63110","63120"],"jurisdiction":"england-wales","company_name":"BEEF
+        LTD","registered_office_address":{"address_line_2":"Bath Road","locality":"Bristol","postal_code":"BS4
+        3EH","address_line_1":"Unit 1.10 The Paintworks"},"company_number":"05868270","undeliverable_registered_office_address":false,"accounts":{"accounting_reference_date":{"month":"08","day":"31"},"last_accounts":{"type":"total-exemption-small","made_up_to":"2012-08-31"}},"has_insolvency_history":true,"etag":"d40ffbea6e7243a46b5626710fdfcb29c515cb62","company_status":"dissolved","has_charges":false,"links":{"self":"/company/05868270","filing_history":"/company/05868270/filing-history","officers":"/company/05868270/officers","insolvency":"/company/05868270/insolvency"},"registered_office_is_in_dispute":false,"date_of_cessation":"2016-12-13","can_file":false}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:27:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/registration/upper_business_details_step_uk_limited_company_postcode_lookup_address_behaves_like_a_uk_company_number_step_should_allow_active_company.yml
+++ b/spec/vcr/registration/upper_business_details_step_uk_limited_company_postcode_lookup_address_behaves_like_a_uk_company_number_step_should_allow_active_company.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/02050399
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1601'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '598'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"company_number":"02050399","accounts":{"accounting_reference_date":{"month":"03","day":"31"},"next_due":"2018-12-31","next_made_up_to":"2018-03-31","overdue":false,"last_accounts":{"period_start_on":"2016-04-01","made_up_to":"2017-03-31","type":"micro-entity","period_end_on":"2017-03-31"},"next_accounts":{"period_end_on":"2018-03-31","overdue":false,"period_start_on":"2017-04-01","due_on":"2018-12-31"}},"jurisdiction":"england-wales","registered_office_address":{"region":"Mid
+        Glamorgan","locality":"Caerphilly","postal_code":"CF83 1BR","address_line_1":"15
+        Lon Uchaf Lon Uchaf"},"last_full_members_list_date":"2015-12-31","date_of_creation":"1986-08-28","type":"ltd","has_been_liquidated":false,"company_name":"ZENITH
+        PRINT (UK) LIMITED","sic_codes":["70100"],"undeliverable_registered_office_address":false,"has_insolvency_history":false,"etag":"9c6b544fbd0427cdfbb53e0870ca8fa32c084470","company_status":"active","has_charges":true,"previous_company_names":[{"ceased_on":"1996-03-22","effective_from":"1993-04-22","name":"ZENITH
+        TREFOREST PRESS LIMITED"},{"name":"ZENITH COLOUR PRINTING LIMITED","ceased_on":"1993-04-22","effective_from":"1986-11-14"},{"effective_from":"1986-08-28","ceased_on":"1986-11-14","name":"CHANCETACKLE
+        LIMITED"}],"confirmation_statement":{"last_made_up_to":"2017-12-31","next_made_up_to":"2018-12-31","overdue":false,"next_due":"2019-01-14"},"links":{"self":"/company/02050399","filing_history":"/company/02050399/filing-history","officers":"/company/02050399/officers","charges":"/company/02050399/charges"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:27:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/registration/upper_business_details_step_uk_limited_company_postcode_lookup_address_behaves_like_a_uk_company_number_step_should_not_allow_company_which_is_not_active.yml
+++ b/spec/vcr/registration/upper_business_details_step_uk_limited_company_postcode_lookup_address_behaves_like_a_uk_company_number_step_should_not_allow_company_which_is_not_active.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/05868270
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Feb 2018 14:28:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '969'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '599'
+      X-Ratelimit-Reset:
+      - '1517927615'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"has_been_liquidated":true,"last_full_members_list_date":"2013-07-06","date_of_creation":"2006-07-06","type":"ltd","sic_codes":["62012","63110","63120"],"jurisdiction":"england-wales","company_name":"BEEF
+        LTD","registered_office_address":{"address_line_2":"Bath Road","locality":"Bristol","postal_code":"BS4
+        3EH","address_line_1":"Unit 1.10 The Paintworks"},"company_number":"05868270","undeliverable_registered_office_address":false,"accounts":{"accounting_reference_date":{"month":"08","day":"31"},"last_accounts":{"type":"total-exemption-small","made_up_to":"2012-08-31"}},"has_insolvency_history":true,"etag":"d40ffbea6e7243a46b5626710fdfcb29c515cb62","company_status":"dissolved","has_charges":false,"links":{"self":"/company/05868270","filing_history":"/company/05868270/filing-history","officers":"/company/05868270/officers","insolvency":"/company/05868270/insolvency"},"registered_office_is_in_dispute":false,"date_of_cessation":"2016-12-13","can_file":false}'
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 14:27:53 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
The project uses VCR to mock out http interactions between it and external services. Till now the cassettes would be recreated each time someone new cloned the project, however this generally led to time needing to be spent to either update the specs to match what the API was now actually returning, or to use keys that would return records that matched what was expected.

It wasn't actually about updating the specs because the API itself had changed, or the logic in the code. It was just the data being returned had changed and no longer matched what the test needed.

Therefore to stop this, this change brings back into the project the missing cassettes. It ensures our companies house auth key is not included with the files, and what's left is data captured when our internal services were returning dummy data.

Now the next dev that comes along and needs to run the rspec suite should find it passes on first pass.