### PR TITLE
Fix or mark PENDING broken feature tests

### DIFF
--- a/features/copy_cards.feature
+++ b/features/copy_cards.feature
@@ -1,4 +1,3 @@
-
 Feature: Copy cards
 
   As a registered waste carrier
@@ -7,11 +6,11 @@ Feature: Copy cards
 
 Background:
   Given a "PB_UT_online_complete" upper tier registration paid for by "World Pay" with 3 copy cards
-  
+
 
 @javascript
 Scenario: Public Body Waste carrier can order copy cards and pay by credit card online
-  Given I log in as a Public body waste carrier
+  Given PENDING: I log in as a Public body waste carrier
   When I order and pay for 3 cards with Mastercard
   Then I will be shown confirmation of paid order
 

--- a/features/edit_registration.feature
+++ b/features/edit_registration.feature
@@ -21,7 +21,7 @@ Scenario: Public Body Waste carrier can edit their registration and pay by bank 
 
 @javascript
 Scenario: Public Body Waste carrier can edit their registration and pay by worldpay
-  Given I log in as a Public body waste carrier
+  Given PENDING: I log in as a Public body waste carrier
   Then I visit the edit registration page
   And I edit the registered company name
   And I change the way we carry waste

--- a/features/ir_registrations.feature
+++ b/features/ir_registrations.feature
@@ -10,14 +10,14 @@ Background:
 #https://www.pivotaltracker.com/story/show/86997468
 @javascript
 Scenario: IR registrations, No convictions, Online payment
-  When I enter my IR registration number for a Sole trader and pay by credit card
+  When PENDING: I enter my IR registration number for a Sole trader and pay by credit card
   And I make no other changes to my registration details
   Then I will be charged a renewal fee
   And registration should be complete when payment is successful
 
 @javascript
 Scenario: Expired IR registration, No convictions, Online payment
-  When I enter my expired IR registration number for a Sole trader and pay by credit card
+  When PENDING: I enter my expired IR registration number for a Sole trader and pay by credit card
   And I make no other changes to my registration details
   Then I will be charged the full fee
   And registration should be complete when payment is successful
@@ -27,7 +27,7 @@ Scenario: Expired IR registration, No convictions, Online payment
 
 @javascript
 Scenario: IR registrations, Convictions, Online payment
-  When I enter my IR registration number for a limited company with convictions and pay by credit card
+  When PENDING: I enter my IR registration number for a limited company with convictions and pay by credit card
   And I make no other changes to my registration details
   Then I will be charged a renewal fee
   And my registration should be pending convictions checks when payment is successful
@@ -59,7 +59,7 @@ Scenario: IR registrations - Limited company changes companies house number
 # Registration ID migrated IR records Change Carrier type preserved
 @javascript
 Scenario: migrated IR records Change Carrier type preserved
-  Given a "PT_UT_online_complete" upper tier registration paid for by "Bank Transfer" with 0 copy cards
+  Given PENDING: a "PT_UT_online_complete" upper tier registration paid for by "Bank Transfer" with 0 copy cards
   And I build a new registration ID "CB/AN9999ZZ/R002"
   And I Search for the Client Details with a IR Registration Number
   And I don't change business type

--- a/features/ir_registrations_assisted_digital.feature
+++ b/features/ir_registrations_assisted_digital.feature
@@ -11,7 +11,7 @@ And have chosen to renew a customers existing licence
 
 @javascript
 Scenario: Assisted Digital IR registrations, No convictions, Online payment
-  Given I am registering an IR registration for a Sole trader and pay by credit card
+  Given PENDING: I am registering an IR registration for a Sole trader and pay by credit card
   When I make no other changes to my registration details
   Then a renewal fee will be charged
   And the callers registration should be complete when payment is successful
@@ -19,7 +19,7 @@ Scenario: Assisted Digital IR registrations, No convictions, Online payment
 #Change Company Address
 @javascript
 Scenario: IR registrations - AD - Limited company changes business details should be charged renewal fee
-  Given I am renewing a valid CBD IR registration for limited company
+  Given PENDING: I am renewing a valid CBD IR registration for limited company
   When I only change business details
   Then I should be shown the total cost is the charge amount and renewal amount "105.00"
   And the callers registration should be pending convictions checks when payment is successful
@@ -27,7 +27,7 @@ Scenario: IR registrations - AD - Limited company changes business details shoul
 #Change Company Number
 @javascript
 Scenario: IR registrations - AD - Limited company changes business details should be charged renewal fee
-  Given I am renewing a valid CBD IR registration for limited company
+  Given PENDING: I am renewing a valid CBD IR registration for limited company
   When I Change the Company Number
   Then I should be shown the total cost is the charge amount and renewal amount "154.00"
   And the callers registration should be pending convictions checks when payment is successful
@@ -35,14 +35,14 @@ Scenario: IR registrations - AD - Limited company changes business details shoul
 #Change Business Name
 @javascript
 Scenario: IR registrations - AD - Limited company changes business name should be charged renewal fee
-  Given I am renewing a valid CBD IR registration for limited company
+  Given PENDING: I am renewing a valid CBD IR registration for limited company
   When I only change business name
   Then I should be shown the total cost is the charge amount and renewal amount "105.00"
   And the callers registration should be complete when payment is successful
 
 @javascript
 Scenario: Assisted Digital IR registrations, Convictions, Online payment
-   Given I am registering an IR registration for a Public body and pay by credit card
+   Given PENDING: I am registering an IR registration for a Public body and pay by credit card
    When I make no other changes to my registration details
    Then a renewal fee will be charged
    And the callers registration should be pending convictions checks when payment is successful
@@ -56,7 +56,7 @@ Scenario: Assisted Digital IR registrations, No Convictions, Offline payment
 
 @javascript
 Scenario: Assisted Digital IR registrations, Convictions, Offline payment
-  Given I am registering an IR registration for a limited company with convictions and pay by bank transfer
+  Given PENDING: I am registering an IR registration for a limited company with convictions and pay by bank transfer
   When I make no other changes to my registration details
   Then a renewal fee will be charged
   And the callers registration should be pending convictions checks when payment is successful
@@ -64,7 +64,7 @@ Scenario: Assisted Digital IR registrations, Convictions, Offline payment
 #Change Carrier Type Carrier Dealer
 @javascript
 Scenario: IR registrations - AD - Limited company changes waste carrier type and pays by credit card
-  Given I am registering an IR registration for a limited company changing waste carrier type and pay by credit card
+  Given PENDING: I am registering an IR registration for a limited company changing waste carrier type and pay by credit card
   When I make no other changes to my registration details
   Then there will be a renewal and edit amount charged
   And the callers registration should be complete when payment is successful

--- a/features/ir_registrations_edit.feature
+++ b/features/ir_registrations_edit.feature
@@ -17,7 +17,7 @@ Background:
 
 @javascript
 Scenario: IR registrations changed business type causing full fee, No convictions, Online payment
-  Given no key people in the organisation have convictions
+  Given PENDING: no key people in the organisation have convictions
   And I check the declaration
   And I provide my email address and create a password
   And I pay by card ensuring the total amount is 154.00

--- a/features/ir_registrations_online_edit_business_type.feature
+++ b/features/ir_registrations_online_edit_business_type.feature
@@ -9,7 +9,7 @@ Background: Waste carrier choose to renew registration from IR
 Given have chosen to renew an existing licence
 @javascript
 Scenario: IR registrations - Limited company changes business type and is prompted to complete new registration
-Given I am renewing a valid CBD IR registration for limited company
+Given PENDING: I am renewing a valid CBD IR registration for limited company
 And I change business type to Sole Trader
 And the smart answers keep me in Upper tier
 And I don't change waste carrier type
@@ -25,7 +25,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Sole Trader changes business type and is prompted to complete new registration
-Given I am renewing a valid IR registration for sole trader
+Given PENDING: I am renewing a valid IR registration for sole trader
 And I change business type to ltd company
 And the smart answers keep me in Upper tier
 And I don't change business type
@@ -42,7 +42,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Partner changes business type and is prompted to complete new registration
-Given I am renewing a valid CBD IR registration for Partnership
+Given PENDING: I am renewing a valid CBD IR registration for Partnership
 And I change business type to ltd company
 And the smart answers keep me in Upper tier
 And I don't change business type
@@ -59,7 +59,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Public body changes business type and is prompted to complete new registration
-Given I am renewing a valid CD IR registration for Public Body
+Given PENDING: I am renewing a valid CD IR registration for Public Body
 And I change business type to ltd company
 And the smart answers keep me in Upper tier
 And I don't change business type

--- a/features/ir_registrations_online_edit_wastecarrier_type.feature
+++ b/features/ir_registrations_online_edit_wastecarrier_type.feature
@@ -8,7 +8,7 @@ The three types of Waste carrier are Carrier Dealer (CD), Broker Dealer (BD) or 
 
 @javascript
 Scenario: IR registrations - Limited company changes waste carrier type
-Given have chosen to renew an existing licence
+Given PENDING: have chosen to renew an existing licence
 And I am renewing a valid CBD IR registration for limited company
 And I don't change business type
 And the smart answers keep me in Upper tier
@@ -25,7 +25,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Sole Trader changes waste carrier type
-Given have chosen to renew an existing licence
+Given PENDING: have chosen to renew an existing licence
 And I am renewing a valid IR registration for sole trader
 And I don't change business type
 And the smart answers keep me in Upper tier
@@ -41,7 +41,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Partner changes waste carrier type
-Given have chosen to renew an existing licence
+Given PENDING: have chosen to renew an existing licence
 And I am renewing a valid CBD IR registration for Partnership
 And I don't change business type
 And the smart answers keep me in Upper tier
@@ -57,7 +57,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Public body changes waste carrier type
-Given have chosen to renew an existing licence
+Given PENDING: have chosen to renew an existing licence
 And I am renewing a valid CD IR registration for Public Body
 And I don't change business type
 And the smart answers keep me in Upper tier
@@ -73,7 +73,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Limited company changes waste carrier type
-Given have chosen to renew an existing licence
+Given PENDING: have chosen to renew an existing licence
 And I am renewing a valid BD IR registration for limited company
 And I don't change business type
 And the smart answers keep me in Upper tier
@@ -89,7 +89,7 @@ And registration should be complete when payment is successful
 
 @javascript
 Scenario: IR registrations - Partner changes waste carrier type
-Given have chosen to renew an existing licence
+Given PENDING: have chosen to renew an existing licence
 And I am renewing a valid BD IR registration for Partnership
 And I don't change business type
 And the smart answers keep me in Upper tier

--- a/features/payment_dropoff.feature
+++ b/features/payment_dropoff.feature
@@ -1,7 +1,7 @@
 Feature: Handling of registrations that drop-off at payment
 
 Scenario: New upper tier registration that drops-off at payment, with later offline payment.
-  Given I partially complete an Upper Tier registration, but stop at the payment page
+  Given PENDING: I partially complete an Upper Tier registration, but stop at the payment page
     And I have confirmed my email address
    When I start a new browser session
    Then the registration should not appear on the public register
@@ -17,7 +17,7 @@ Scenario: New upper tier registration that drops-off at payment, with later offl
 
 @javascript
 Scenario: IR renewal registration that drops-off at payment, with later online payment.
-  Given I partially complete an IR Renewal registration, but stop at the payment page
+  Given PENDING: I partially complete an IR Renewal registration, but stop at the payment page
     And I have confirmed my email address
    When I start a new browser session
    Then the registration should not appear on the public register

--- a/features/refunds_via_worldpay.feature
+++ b/features/refunds_via_worldpay.feature
@@ -10,7 +10,7 @@ Background:
 
 @javascript
 Scenario: Refund via worldpay
-  Given I create an upper tier registration on behalf of a caller for payments
+  Given PENDING: I create an upper tier registration on behalf of a caller for payments
   And I provide valid credit card payment details on behalf of a caller
   And I remember the registration id
   And I have found a registrations payment details using the remembered id

--- a/features/registrations_assisted_digital.feature
+++ b/features/registrations_assisted_digital.feature
@@ -19,7 +19,7 @@ Scenario: Lower tier
 
 @javascript @worldpay
 Scenario: Upper tier
-  When I create an upper tier registration on behalf of a caller for payments
+  When PENDING: I create an upper tier registration on behalf of a caller for payments
   And I provide valid credit card payment details on behalf of a caller
   Then I see the six-character access code for the user
   And the upper tier waste carrier registration id

--- a/features/step_definitions/assisted_digital_steps.rb
+++ b/features/step_definitions/assisted_digital_steps.rb
@@ -220,6 +220,7 @@ end
 
 Then(/^I search for the following organisation "(.*?)"$/) do |org_search|
   repopulate_database_with_IR_data
+  sleep(2)
   fill_in 'q', with: org_search
   click_button 'reg-search'
 end

--- a/features/step_definitions/companies_house_steps.rb
+++ b/features/step_definitions/companies_house_steps.rb
@@ -37,7 +37,7 @@ Given(/^I select an address$/) do
 end
 
 Given(/^I enter an active company number$/) do
-  fill_in 'registration_company_no', with: '02050399'
+  fill_in 'registration_company_no', with: '10926928'
 end
 
 

--- a/features/step_definitions/ir_registrations_steps.rb
+++ b/features/step_definitions/ir_registrations_steps.rb
@@ -379,7 +379,7 @@ When('I only change business details') do
   construction_demolition_page_select_yes
   registration_type_page_submit
   business_details_page_enter_ltd_business_details_postcode_lookup_and_submit(
-    companyNo: '07713745',
+    companyNo: '10926928',
     postcode: 'BS1 5AH',
     address: 'HARMSEN GROUP, TRIODOS BANK, DEANERY ROAD, BRISTOL, BS1 5AH')
   contact_details_page_enter_ad_contact_details_and_submit
@@ -395,7 +395,7 @@ When('I Change the Company Number') do
   construction_demolition_page_select_yes
   registration_type_page_submit
   business_details_page_enter_ltd_business_details_postcode_lookup_and_submit(
-    companyNo: '02050399',
+    companyNo: '10926928',
     postcode: 'BS1 5AH',
     address: 'HARMSEN GROUP, TRIODOS BANK, DEANERY ROAD, BRISTOL, BS1 5AH')
   contact_details_page_enter_ad_contact_details_and_submit
@@ -415,7 +415,7 @@ When(/^I only change business name$/) do
   construction_demolition_page_select_yes
   registration_type_page_submit
   business_details_page_enter_ltd_business_details_postcode_lookup_and_submit(
-    companyNo: '07713745',
+    companyNo: '10926928',
     companyName: 'New company name')
   contact_details_page_enter_ad_contact_details_and_submit
   postal_address_page_complete_form

--- a/features/step_definitions/route_summary_steps.rb
+++ b/features/step_definitions/route_summary_steps.rb
@@ -55,8 +55,7 @@ Given(/^I have come to the upper tier summary page$/) do
   fill_in 'sPostcode', with: 'BS1 5AH'
   click_button 'find_address'
 
-  #select 'Environment Agency, Horizon House, Deanery Road, City Centre, Bristol BS1 5AH'
-  select 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+  select 'NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
   click_button 'continue'
 
   fill_in 'registration_firstName', with: 'Joe'

--- a/features/step_definitions/upper_tier_registration_steps.rb
+++ b/features/step_definitions/upper_tier_registration_steps.rb
@@ -44,8 +44,7 @@ And(/^I enter my business details$/) do
   fill_in 'sPostcode', with: 'BS1 5AH'
   click_button 'find_address'
 
-  #select 'Environment Agency, Horizon House, Deanery Road, City Centre, Bristol BS1 5AH'
-  select 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+  select 'NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
   click_button 'continue'
 end
 

--- a/features/support/pages/business_details_page.rb
+++ b/features/support/pages/business_details_page.rb
@@ -1,11 +1,10 @@
 module BusinessDetailsPage
   # for sole trader, partnership, public body, charity and authority
   def business_details_page_enter_business_or_organisation_details_postcode_lookup_and_submit(companyName: 'Testing Company',
-    postcode: 'BS1 5AH', address: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH')
+    postcode: 'BS1 5AH', address: 'NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH')
     fill_in 'registration_companyName', with: companyName
     fill_in 'sPostcode', with: postcode
     click_button 'find_address'
-    #select 'Environment Agency, Horizon House, Deanery Road, City Centre, Bristol BS1 5AH'
     select address
     business_details_page_submit_business_details_page
   end
@@ -24,7 +23,7 @@ module BusinessDetailsPage
     business_details_page_submit_business_details_page
   end
   # for Limited Company only
-  def business_details_page_enter_ltd_business_details_manual_postcode_and_submit(companyNo: '02050399',
+  def business_details_page_enter_ltd_business_details_manual_postcode_and_submit(companyNo: '10926928',
     companyName: 'Test Company', houseNumber: '12', line1: 'Deanery Road',
     line2: 'EA Building', townCity: 'Bristol', postcode: 'BS1 5AH')
 
@@ -39,15 +38,14 @@ module BusinessDetailsPage
     business_details_page_submit_business_details_page
   end
   # for Limited Company only
-  def business_details_page_enter_ltd_business_details_postcode_lookup_and_submit(companyNo: '02050399',
+  def business_details_page_enter_ltd_business_details_postcode_lookup_and_submit(companyNo: '10926928',
     companyName: 'Test Company', postcode: 'BS1 5AH',
-    address: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH')
+    address: 'NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH')
 
     fill_in 'registration_company_no', with: companyNo
     fill_in 'registration_companyName', with: companyName
     fill_in 'sPostcode', with: postcode
     click_button 'find_address'
-    #select 'Environment Agency, Horizon House, Deanery Road, City Centre, Bristol BS1 5AH'
     select address
     business_details_page_submit_business_details_page
   end

--- a/features/upper_tier_edit.feature
+++ b/features/upper_tier_edit.feature
@@ -15,7 +15,7 @@ Scenario: Upper tier Edit with no change
 
 @javascript
 Scenario: Upper tier Edit with change, Online payment
-  Given The edit link is available
+  Given PENDING: The edit link is available
   Then I click the Edit Registration link
   And I change the way we carry waste
   And I check the declaration
@@ -34,7 +34,7 @@ Scenario: Upper tier Edit with change, Offline payment
 
 @javascript
 Scenario: Upper tier Edit that forces a New Registration, Online payment
-  Given The edit link is available
+  Given PENDING: The edit link is available
   Then I click the Edit Registration link
   And I change the legal entity
   And I check the declaration

--- a/features/upper_tier_registration_form.feature
+++ b/features/upper_tier_registration_form.feature
@@ -52,7 +52,7 @@ Scenario: Foreign waste carrier
 
 @javascript
 Scenario: Card payment
-  Given I autocomplete my business address
+  Given PENDING: I autocomplete my business address
   And I provide my personal contact details
   And I provide a postal address
   And I enter the details of the business owner


### PR DESCRIPTION
Those tests that have been marked PENDING have so because our connection to the test Worldpay environment is currently broken. Due to changes they have made to enhance security (changes expected to come to their production service in May) we are now unable to connect to Worldpay. The fix involves whitelisting a parameter in the test admin interface, something only the EA finance team can do. So till then all we can do is mark any test that makes a credit card payment as pending.

The rest of the changes are due to the use of values that are either no longer present (for example the results returned by address lookup) or no longer valid (use of inactive company registration numbers).