### PR TITLE
Fix README details and defaults for services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Environment Variables for the Waste Carriers Registration service, Ruby-on-Rails front-end.
 
 # Supporting Java/DropWizard services
-WCRS_FRONTEND_WCRS_SERVICES_URL="http://localhost:9090"
-WCRS_FRONTEND_WCRS_ADDRESSES_URL="http://localhost:9190"
+WCRS_FRONTEND_WCRS_SERVICES_URL="http://localhost:8004"
+WCRS_FRONTEND_WCRS_ADDRESSES_URL="http://localhost:8006"
 WCRS_FRONTEND_CONVICTIONS_SERVICE_URL="http://localhost:9290"
 
 # Hosting environment

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,8 @@
-The MIT License (MIT)
+The Open Government Licence (OGL) Version 3
 
-Copyright (c) 2013 EnvironmentAgency
+Copyright (c) 2018 Environment Agency
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -1,177 +1,99 @@
-# waste-carriers-frontend
-
-Waste Carriers Registration Service Frontend application.
+# Waste carriers frontend
 
 The Waste Carrier Registrations Service allows businesses, who deal with waste and thus have to register according to the regulations, to register online. Once registered, businesses can sign in again to edit their registrations if needed.
 
-The service also allows authorised agency users and NCCC contact centre staff to create and manage registrations on other users behalf, e.g. to support 'Assisted Digital' registrations. The service provides an internal user account management facility which allows authorised administrators to create and manage other agency user accounts.
+The service also allows authorised agency users and NCCC contact centre staff to create and manage registrations on a user's behalf, e.g. to support 'Assisted Digital' registrations. The service provides an internal user account management facility which allows authorised administrators to create and manage other agency user accounts.
 
 The service is implemented as a frontend web application, with a service API and a document-oriented database (MongoDB) underneath.
 
-The frontend application is a Ruby on Rails 4 application, which accesses a RESTful services layer implemented in Java.
-The services layer provides a RESTful API to manage (create, read, update, delete) registrations.
-The service layer in turn accesses a MongoDB database.
+- The frontend application is a Ruby on Rails 4 application, which accesses a RESTful services layer implemented in Java.
+- The services layer provides a RESTful API to manage (create, read, update, delete) registrations.
+- The service layer in turn accesses a MongoDB database.
 
 For authentication purposes the application uses the Devise gem (https://github.com/plataformatec/devise) to manage the user accounts of waste carriers (i.e. external users), and internal users (agency users such as NCCC contact centre staff and administrators). User account information managed by the Devise gem is stored in MongoDB.
 
-It is expected that external user authentication will be migrated to mechanisms provided by the GOV.UK ID Assurance program, once these become available.
-
-The application sends emails using the Sendgrid e-mail service.
-
-## Installation
-
-Clone the repository, copying the project into a working directory:
-
-	$ git clone https://github.com/DEFRA/waste-carriers-frontend.git
-
-A Vagrantfile has been created allowing easy setup of the Rails frontend and the associated backend Java services. This is located within Gitlab.
-
-## Configuration
-
-The application contains a variety of configurable settings, which are set in several files located in the /config directory.
-Environment-related configuration settings are located in the /config/environments directory, e.g. development.rb, production.rb, etc.
-
-The frontend application expects the services to run on http://localhost:9090, unless configured otherwise.
-
-You may want or need to set the following environment variables, e.g. in your `~/.bash_profile` or `~/.zshrc`. Adjust these as required for your local setup:
-
-	## Sendgrid configuration - for sending emails
-	export WCRS_FRONTEND_EMAIL_USERNAME="<your sendgrid username here>"
-	export WCRS_FRONTEND_EMAIL_PASSWORD="<your sendgrid password here>"
-	export WCRS_FRONTEND_EMAIL_HOST="smtp.sendgrid.net"
-	export WCRS_FRONTEND_EMAIL_PORT=25
-	## Waste Carriers Service
-	export WCRS_FRONTEND_WCRS_SERVICES_URL="http://localhost:9090"
-	export WCRS_FRONTEND_PUBLIC_APP_DOMAIN="<your-public-domain-subdomain-here>"
-	export WCRS_FRONTEND_ADMIN_APP_DOMAIN="<your-admin-domain-subdomain-here>"
-	## The two subdomains are used by Devise to send out emails - specify without the protocol and the 'main' domain
-	export WCRS_FRONTEND_PUBLIC_APP_SUBDOMAIN="<your-subdomain-here>"
-	export WCRS_FRONTEND_ADMIN_APP_SUBDOMAIN="<your-subdomain-here>"
-	## Database parameters (for accessing user accounts managed by Devise)
-	export WCRS_FRONTEND_USERSDB_NAME="waste-carriers-users"
-	export WCRS_FRONTEND_USERSDB_USERNAME=mongoUser
-	export WCRS_FRONTEND_USERSDB_PASSWORD=<your mongo password here>
-	export WCRS_FRONTEND_USERSDB_URL=localhost:27017
-	export WCRS_FRONTEND_USERSDB_URL2=localhost:28017
-	export WCRS_FRONTEND_USERSDB_URL3=localhost:29017
-	##for Saucelabs cross-browser testing:
-	export SAUCE_USERNAME=<your saucelabs username>
-	export SAUCE_ACCESS_KEY=<your sauce access key>
-
-You may want to edit your local 'hosts' file to have entries for the public and admin domains and subdomains.
+The application sends emails using the [Sendgrid](https://sendgrid.com/) e-mail service.
 
 ## Prerequisites
 
-* Ubuntu (or similar Linux distribution)
-* Git
-* Access to GitHub
-* Ruby 2.0.0
-	* recommended: use RVM - the Ruby Version Manager
-* Rails 4.0
-* Redis (version 2.8.x) - for temporary session storage
-* The running services layer (build and deploy waste-carriers-service)
-* Java 7 JDK - for building the services layer
-* Maven (version 3.0 or above) - for building the services layer
-* MongoDB (version 2.4.6 or above) - to store registrations and user accounts
-* ElasticSearch (version 0.90.5 or above) - for full-text search
+- Ruby 2.4.2
+- Redis (version 2.8.x) - for temporary session storage
+- MongoDb (version 3.6) - to store registrations and user accounts
+
+## Installation
+
+Clone the repo and drop into the project
+
+```bash
+git clone https://github.com/DEFRA/waste-carriers-frontend.git && cd waste-carriers-frontend
+```
+
+Then install the dependencies `bundle install`.
+
+## Running locally
+
+A [Vagrant instance](https://www.vagrantup.com/) has been created allowing easy setup of the waste carriers service. It includes installing all applications, databases and dependencies. This is located within Gitlab (speak to the ruby team).
+
+Download the vagrant project and create the VM using the instructions in its README. It includes installing and running a version of the frontend app, however if you intend to work with it locally and just use the box for dependencies you'll need to:
+
+- Login into the vagrant instance then using `ps ax` identify the pid of the running frontend app
+- Kill it using `kill [pid id]`
+- Exit the vagrant instance
+
+Once you've created a `.env` file (see below) you should be reading to work with and run the project locally.
+
+## Configuration
+
+Most settings are driven through environment variables as per [12 factor app](https://12factor.net/config), however when working locally we use [Dotenv](https://github.com/bkeepers/dotenv) and a `.env` file to load them. This saves having to add them to each session or update your `~/.bash_profile`. See `.env.example` for details of the environment variables that can be set. Also check the environment files as detailed above, because in some cases a default will be used negating the need to set the environment variable.
 
 ## wkhtmltopdf
 
-We use wkhtmltopdf to create PDF files. On Ubuntu this can be installed like so:
+We use wkhtmltopdf to create PDF files. On Ubuntu this can be installed with
 
 `sudo apt-get install wkhtmltopdf`
 
-## Build and Deploy
-
-As is standard with Rails applications, navigate to the project directory, and execute the following:
-
-Install missing gems:
-
-	$ bundle install
-
-Start the Rails application web server:
-
-	$ rails server
-
-This will start the Rails development server (in development mode), by default on port 3000 (http://localhost:3000).
-
-Once the application server is started you should be able to access the application in your browser on
-
-	http://localhost:3000
-
 ## User Guide
 
-While in development, the application contains a (temporary) root index page which shows a variety of links for the typical entry points into the application. Note: this page may be removed at a later stage.
+While in development, the application contains a (temporary) root index page which shows a variety of links for the typical entry points into the application.
 
-## Starting up prerequisites
+## Testing the app
 
-### Redis
+### Unit Tests
 
-Startup Redis using:
+RSpec unit tests are available. Run `bundle exec rspec` to run all tests.
 
-For local development:
+Unit tests aree located in the `spec` directory.
 
-	$ redis-server
+### Feature Tests
 
-This starts Redis with default settings, which is suitable for development.
-To start Redis with configuration settings, specify a path to a configuration file.
-A sample development configuration file is located in the db directory.
+Cucumber feature tests are available. Run `bundle exec cucumber` to run all tests.
 
-	$ redis-server db/redis.conf
-
-### Waste Carriers Service
-
-Please refer to the 'waste-carriers-service' project for details.
-
-https://github.com/DEFRA/waste-carriers-service
-
-### Address Lookup Service
-
-Please refer to the 'os-places-address-lookup' project for details.
-
-https://github.com/DEFRA/os-places-address-lookup
-
-## Run Tests
-
-### Rspec Tests
-
-RSpec tests are available. Run `rspec` in this projects root.
-
-### Acceptance Tests - using Cucumber
-
-To run the Cucumber-based acceptance tests, navigate to the application project directory, and execute from the command line / Terminal window:
-
-	$ cucumber
-
-Acceptance tests are located in the features directory.
-
-### Cross-Browser Tests
-
-We use Saucelabs to run cross-browser and cross-platform tests.
-Saucelabs supports a variety of languages and testing frameworks, including RSpec and Cucumber for Ruby and Rails based development.
-
-Cucumber-based tests are work-in-progress and sometimes fail due to connectivity and timeout problems.
-
-To run the Cucumber-based tests against Saucelabs, execute:
-
-	$ rake sauce:features
-
-To run RSpec-based tests against Saucelabs, execute:
-
-	$ rake sauce:spec
+Feature tests are located in the `features` directory.
 
 ## Related Resources
 
-Ruby on Rails: http://rubyonrails.org
+- [Ruby on Rails](http://rubyonrails.org)
+- [MongoDB](http://www.mongodb.org)
+- [ElasticSearch](http://www.elasticsearch.org)
+- [Apache Maven](http://www.elasticsearch.org)
+- [Redis](http://redis.io)
 
-MongoDB: http://www.mongodb.org
+## Contributing to this project
 
-ElasticSearch: http://www.elasticsearch.org
-
-Apache Maven: http://www.elasticsearch.org
-
-Redis: http://redis.io
+Please read the [contribution guidelines](/CONTRIBUTING.md) before submitting a pull request.
 
 ## License
 
-TBD
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
+
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+>Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,9 +56,9 @@ module Registrations
     # service API.  As described in the comments above, this setting can be
     # redefined in 'config/environments/*.rb'.
     # Changing this value requires restart of the application.
-    config.waste_exemplar_services_url            = get_url_from_environment_or_default('WCRS_FRONTEND_WCRS_SERVICES_URL',       'http://localhost:9090')
-    config.waste_exemplar_services_admin_url      = get_url_from_environment_or_default('WCRS_FRONTEND_WCRS_SERVICES_ADMIN_URL', 'http://localhost:9091')
-    config.waste_exemplar_addresses_url           = get_url_from_environment_or_default('WCRS_FRONTEND_WCRS_ADDRESSES_URL',      'http://localhost:9190')
+    config.waste_exemplar_services_url            = get_url_from_environment_or_default('WCRS_FRONTEND_WCRS_SERVICES_URL',       'http://localhost:8004')
+    config.waste_exemplar_services_admin_url      = get_url_from_environment_or_default('WCRS_FRONTEND_WCRS_SERVICES_ADMIN_URL', 'http://localhost:8005')
+    config.waste_exemplar_addresses_url           = get_url_from_environment_or_default('WCRS_FRONTEND_WCRS_ADDRESSES_URL',      'http://localhost:8006')
     config.waste_exemplar_elasticsearch_url       = get_url_from_environment_or_default('WCRS_ELASDB_URL_REST',                  'http://localhost:9200')
 
     # The application URL.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-157
https://eaflood.atlassian.net/browse/WC-159

After updating the Waste carriers service and OS Places address lookup projects the defaults for them have changed. This change covers updating the defaults and info relating to them in the README.

Whilst in the README also took the time to clear up the other information it contains to better reflect the current state of the service and project.