### PR TITLE
Update url for address lookup

### DIFF
--- a/app/models/address_search_result.rb
+++ b/app/models/address_search_result.rb
@@ -33,7 +33,7 @@ class AddressSearchResult
 
     do_search(
       format(
-        '%s/addresses.json',
+        '%s/addresses',
         Rails.configuration.waste_exemplar_addresses_url
       ),
       postcode: value
@@ -47,7 +47,7 @@ class AddressSearchResult
 
     result = do_search(
       format(
-        '%s/addresses/%s.json',
+        '%s/addresses/%s',
         Rails.configuration.waste_exemplar_addresses_url,
         value
       ),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-366

WC-366 is a story about adding the ability to 'mock' interactions with Worldpay in preparation for performance testing. As part of that story some general refactoring of the OS Places address lookup project were undertaken, including removing the need to specify `.json` in the url.

This change updates the frontend accordingly.