### PR TITLE
Fix broken conviction check after reg edit

### DIFF
--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -140,7 +140,7 @@ class KeyPerson < Ohm::Model
     result = ConvictionSearchResult.search_person_convictions(
       firstname: first_name,
       lastname:  last_name,
-      dateofbirth: dob
+      dateofbirth: dob_elements_as_string()
     )
 
     conviction_search_result.replace([result])
@@ -200,5 +200,9 @@ class KeyPerson < Ohm::Model
 
   def no_existing_dob_errors?
     (!self.errors.include? :dob_day) && (!self.errors.include? :dob_month) && (!self.errors.include? :dob_year)
+  end
+
+  def dob_elements_as_string
+    "%d-%02d-%02d" % [self.dob_year.to_i, self.dob_month.to_i, self.dob_day.to_i]
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-342

Testing exposed an issue with the convictions check. Creating a new registration isn't an issue and it is correctly flagged. However if you then edit the registration and cause a change that forces a new one, the conviction check o the second pass would error.

After some investigation we were able to pin down the error to

- FE queries services for registration
- Service returns a JSON hash where all the dates are in milliseconds since epoch
- FE initialises registration based on hash
- FE when init the key people correctly converts milliseconds to date, but does not assign it to key_person.dob. Instead it assigns the milliseconds value
- FE then runs conviction check passing services milliseconds date
- Service errors as it is expecting to convert strings like '1981-01-01' into date values

The reason this is now failing as that the current production version of the frontend talks to the old convictions service, and never passed the date of birth to it. Its only because we are now properly using DOB in the conviction check that we are the services to interpret what the front end is sending.

We did initially try just setting key_person.dob to what ApplicationController.helpers.convert_date passes back. However this caused a nunmber of cucumber feature tests to fail.

So instead we just ensure that what we send to the services is what it is expecting by adding a new date formatter to the Key_person class.