### PR TITLE
Update to support using mock worldpay service

### DIFF
--- a/app/controllers/order_controller.rb
+++ b/app/controllers/order_controller.rb
@@ -138,6 +138,7 @@ class OrderController < ApplicationController
       logger.debug "The registration is valid - redirecting to Worldpay..."
       response = send_xml(create_xml(@registration, @order))
       render('new', status: :bad_request) and return unless response
+
       redirect_to get_redirect_url(parse_xml(response.body), @registration, @order.orderCode, order_type_param)
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-365

Though we have got the renewals service working with the new mock worldpay feature in the waste carriers service, the frontend is erroring because it makes http requests in a different way, specifically it assumes its always talking to a service using https.

The changes included here are to allow the frontend to talk to the mock when we need it to.

It also removes some obvious duplication.