### PR TITLE
Set secret_key_base when run under prod & rake

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -24,5 +24,3 @@ production:
       uri: <%= ENV['WCRS_REGSDB_URI'] %>
     users:
       uri: <%= ENV['WCRS_USERSDB_URI'] %>
-    options:
-      raise_not_found_error: false


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-133
https://eaflood.atlassian.net/browse/WC-161

This change resolves an issue that has arisen when we come to try and deploy the project in our environments (not local dev).

We are using [Capistrano](https://github.com/capistrano/capistrano) to deploy the project onto our servers, and the [Capistrano-rails](https://github.com/capistrano/rails) plugin which handles rails specific tasks. The issue in our case is asset compilation.

When Capistrano is run its from the context of a Jenkins instance, and it is making an ssh call to the target instances. In this case the command its running is `$HOME/.rbenv/bin/rbenv exec bundle exec rake assets:precompile`. Run in local dev that is fine, but when run in our environment we get an error

```
Caused by:
Devise.secret_key was not set. Please add the following to your Devise initializer:

  config.secret_key =                                                                                  'db3e8d64661d4adcba523726556e95489c64c90f2d273e7f67f68b879cd875f3170ff5b33f8e143d8a969c2154c0acb49ca2a4867a095d31d47a4cbb698e21a6'
```

Essentially calling this command is starting an instance of rails, and Devise is throwing an issue because it cannot identify a SECRET_KEY to use. This is correct in the context of our environments, because the env vars that configure the app and include a SECRET_KEY do not exist in the shell session being run when `assets:precompile` is called. It exists in local dev because we have a default key when the app is run in development and test modes. We don't have a default when its run in production mode.

Looking into solutions they essentially fall into 3

- **Update your deployment to ensure a SECRET_KEY exists.** This is not practical in our case. We don't want to create one process for this value, and another for all the other env vars and apps we deploy, and we have no scope to change the way we do deployments.
- **Create your own custom Capistrano task to handle asset compilation.** Using this we could then alter the command to be `SECRET_KEY=foo $HOME/.rbenv/bin/rbenv exec bundle exec rake assets: precompile`. However it then means we are maintaining our own custom task for something that is pretty much a standard of Capistrano rails deployments, and its on us to ensure its plugged into the correct  step of the deployment, plus be aware of any changes in how asset compilation is done.
- **Set a default SECRET_KEY for production.** Convention is to not have a default, and definitely never to check the key into your repo. However this is the simplest solution to the problem, and means we do not have to try and change how apps are deployed.

So based on this we're implementing option 3. We initially looked at setting a default value in `secrets.yml` and then aborting if it was used in production mode. However on reflection that was foolish because with no SECRET_KEY_BASE env var and always running in production, we would always end up calling abort even when trying to compile the assets.

So instead we found a solution based on being able to tell

- we are running in production
- we were started by rake
- the secret key is blank

If this is the situation, logic in `config/application.rb` sets `config.secret_key_base` to a dummy value. This stops Devise from erroring and allows the asset compilation to complete.

N.B. We also removed an option from the production mongoid config which would raise an error if no value was set for the database connection for the same reason; it caused an error when running rake tasks like asset precompile.