### PR TITLE
Move renewal root path to logic not env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -105,7 +105,7 @@ module Registrations
     # URL rather than via the public domain and URL.
     config.require_admin_requests = Rails.env.production? || ENV['WCRS_FRONTEND_REQUIRE_ADMIN_REQUESTS'] || false
 
-    config.renewals_service_url = "#{get_url_from_environment_or_default('WCRS_RENEWALS_DOMAIN', 'http://localhost:3000/fo')}/renew/"
+    config.renewals_service_url = "#{get_url_from_environment_or_default('WCRS_RENEWALS_DOMAIN', 'http://localhost:3000')}/fo/renew/"
 
     # Add a URL to represent the GOV.UK page that the process goes to, after the
     # registration happy path.


### PR DESCRIPTION
We previously had made a change to our what we expected the env var WCRS_RENEWALS_DOMAIN to hold from `http://localhost` to `http:/localhost/fo` (for example).

However on reflection this is not reflected in the name of the env var, and our logic in the frontend is already setup to add a path to whatever value is held in it.

So this change amends the code based on us reverting our decision on what the env var will hold, so now the root path `/fo` will be included in the frontend logic.