### PR TITLE
Fix CI reporter rake task breaking cap deploy

### DIFF
--- a/lib/tasks/ci_reporter.rake
+++ b/lib/tasks/ci_reporter.rake
@@ -1,5 +1,8 @@
 #Rake task for ci_reporter, with cucumber
-require 'ci/reporter/rake/rspec'
-task :spec => 'ci:setup:rspec'
 
-require 'ci/reporter/rake/cucumber'
+unless Rails.env.production?
+  require 'ci/reporter/rake/rspec'
+  task :spec => 'ci:setup:rspec'
+
+  require 'ci/reporter/rake/cucumber'
+end


### PR DESCRIPTION
In our new AWS environment the frontend will be deployed using Capistrano. However it is currently failing with the following error

```bash
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as ubuntu@DEVWCRBESSRV001: rake exit status: 1
rake stdout: Nothing written
rake stderr: rake aborted!
LoadError: cannot load such file -- ci/reporter/rake/rspec
/srv/ruby/waste-carriers-frontend/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/srv/ruby/waste-carriers-frontend/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
/srv/ruby/waste-carriers-frontend/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
/srv/ruby/waste-carriers-frontend/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/srv/ruby/waste-carriers-frontend/releases/20180808132507/lib/tasks/ci_reporter.rake:2:in `<top (required)>'
...
```

The reason is that the ci_reporter.rake task is attempting to require gems that are not specified in the production group in the Gemfile. When cap deploys it calls assets:precompile with the environment set to production.

This change ensures that the require statements for the task are not called if the environment is production.