### PR TITLE
Add specific support for ELB health check calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,12 @@ gem 'wicked_pdf'
 # that fail.
 gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler"
 
+# Defines a route for ELB healthchecks. The healthcheck is a piece of Rack
+# middleware that does absolutely nothing, so it is faster than just using the
+# default `/` route, or `/version` as was previously used.
+# The app now returns a 200 from `/healthcheck`
+gem 'aws-healthcheck'
+
 group :test do
   gem 'ci_reporter', '~> 1.9.0'
   gem 'cucumber-rails', '~> 1.4.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       io-like (~> 0.3.0)
     arel (6.0.4)
     awesome_print (1.7.0)
+    aws-healthcheck (1.0.1)
+      rails (>= 3.0)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -345,6 +347,7 @@ DEPENDENCIES
   activeresource (~> 4.0.0)
   airbrake (~> 5.3)
   awesome_print
+  aws-healthcheck
   better_errors
   binding_of_caller
   brakeman


### PR DESCRIPTION
When we deploy our apps to non-development environments they will normally be deployed to multiple instances, with access controlled by a load balancer.

The load balancer will route requests across the instances, and will essentially 'ping' each one to ensure it is still alive and responding. Should an instance stop responding the LB will no longer route traffic to it until it is up and running again.

Previously we have configured our environments to 'ping' `/version`. This is fine and a relatively light weight page. However it does still hit the rails instance and requires the page to be generated and then the response sent back.

Recently there was some confusion about whether health checks from AWS [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html) could run their checks over HTTPS, so we needed to find an option that would allow the app proper to use SSL for all routes, but still provide a 200 response for a health check request over HTTP. One suggested solution was to use the [aws-healthcheck](https://github.com/lserman/aws-healthcheck) gem. As it gets added as rack middleware it could respond before it gets to the rails router, which would redirect the request to HTTPS.

The understanding of the ALB was incorrect, but having found the gem it made sense to add it to the project as its specifically designed for dealing with LB health check calls (which generally ping every few seconds). Providing a simple 200 response would reduce the number of requests the app has to properly respond to, whilst still fulfilling the requirement of the health check.