### PR TITLE
Update email settings and add test email rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       stal
     origin (2.3.1)
     orm_adapter (0.5.0)
-    passenger (5.3.3)
+    passenger (5.3.4)
       rack
       rake (>= 0.8.1)
     poltergeist (1.6.0)
@@ -402,4 +402,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -1,10 +1,9 @@
 class RegistrationMailer < ActionMailer::Base
   helper :application
   helper :registrations
-  default from: "registrations@wastecarriersregistration.service.gov.uk"
 
   # This line should have set the default from name, but didnt in testing,
-  # as such email_with_name variables were created to pass in the email name
+  # as such from_address variables were created to pass in the email name
   #default :from => "\"EA Waste Carriers\" <registrations@wastecarriersregistration.service.gov.uk>"
 
   def welcome_email(user, registration)
@@ -12,12 +11,13 @@ class RegistrationMailer < ActionMailer::Base
     @url = Rails.configuration.subdomain
     @registration = registration
     @pdf = true
-    email_with_name = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
+    from_address = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
+    subject = I18n.t('global.mailer.complete.subject')
     attachments["WasteCarrierRegistrationCertificate-#{registration.regIdentifier}.pdf"] = WickedPdf.new.pdf_from_string(
       render_to_string(pdf: 'certificate', template: 'registrations/certificate', layout: 'pdf.html.erb'),
       {}
     )
-    mail(to: @user.email, subject: I18n.t('global.mailer.complete.subject'), from: email_with_name)
+    mail(to: @user.email, subject: subject, from: from_address)
   end
 
   # Call via: RegistrationMailer.awaitingPayment_email(@user, @registration).deliver_now
@@ -25,9 +25,9 @@ class RegistrationMailer < ActionMailer::Base
     @user = user
     @url = Rails.configuration.subdomain
     @registration = registration
-    email_with_name = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
-    subjectMessage = I18n.t('global.mailer.payment.subject', tier: @registration.tier.downcase, companyName: @registration.companyName)
-    mail(to: @user.email, subject: subjectMessage, from: email_with_name)
+    from_address = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
+    subject = I18n.t('global.mailer.payment.subject', tier: @registration.tier.downcase, companyName: @registration.companyName)
+    mail(to: @user.email, subject: subject, from: from_address)
   end
 
   # Call via: RegistrationMailer.awaitingConvictionsCheck_email(@user, @registration).deliver_now
@@ -35,16 +35,24 @@ class RegistrationMailer < ActionMailer::Base
     @user = user
     @url = Rails.configuration.subdomain
     @registration = registration
-    email_with_name = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
-    subjectMessage = I18n.t('global.mailer.convictions.subject', tier: @registration.tier.downcase, companyName: @registration.companyName)
-    mail(to: @user.email, subject: subjectMessage, from: email_with_name)
+    from_address = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
+    subject = I18n.t('global.mailer.convictions.subject', tier: @registration.tier.downcase, companyName: @registration.companyName)
+    mail(to: @user.email, subject: subject, from: from_address)
   end
 
   # Call via: RegistrationMailer.account_already_confirmed_email(user, is_mid_registration).deliver_now
   def account_already_confirmed_email(user, is_mid_registration)
     @is_mid_registration = is_mid_registration
-    subject = I18n.t('registration_mailer.account_already_confirmed.title')
     from_address = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
+    subject = I18n.t('registration_mailer.account_already_confirmed.title')
     mail(to: user.email, subject: subject, from: from_address)
+  end
+
+  def test_email
+    from_address = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
+    subject = "Waste Carriers Test email"
+    mail(to: Rails.configuration.email_test_address, subject: subject, from: from_address) do |format|
+      format.text(content_type: "text/plain", charset: "UTF-8", content_transfer_encoding: "7bit")
+    end
   end
 end

--- a/app/views/registration_mailer/test_email.text.erb
+++ b/app/views/registration_mailer/test_email.text.erb
@@ -1,0 +1,3 @@
+This is a test email sent from the Waste Carriers Registration service.
+
+https://github.com/DEFRA/waste-carriers-frontend

--- a/config/application.rb
+++ b/config/application.rb
@@ -128,8 +128,18 @@ module Registrations
 
     # The e-mail address shown on the Finish page and used in e-mails sent by
     # the application.
-    config.registrations_service_email = 'registrations@wastecarriersregistration.service.gov.uk'
-    config.registrations_service_emailName = 'Waste Carriers Service'
+    # In our dev environments if we are not using mailcatcher and actually want
+    # to send an email, we must use something other than
+    # registrations@wastecarriersregistration.service.gov.uk. This is because
+    # email recipients like Gmail will check the details of the email against
+    # the production DMARC setup and will spot an inconsistency because we are
+    # not using the production sendgrid credentials to send the email. In most
+    # cases they will then block receipt of the email.
+    # By using something else e.g. wcr-dev@example.com, as no DMARC is set it
+    # will not fail the check so is unlikely to be blocked (but might be flagged
+    # within the email client).
+    config.registrations_service_email = ENV["WCRS_EMAIL_SERVICE_EMAIL"] || 'registrations@wastecarriersregistration.service.gov.uk'
+    config.registrations_service_emailName = 'Waste Carriers Registration Service'
 
     # The phone number shown on the certificate and used in e-mails sent by the
     # application.
@@ -205,5 +215,7 @@ module Registrations
     config.registration_renewal_window = (ENV['WCRS_REGISTRATION_RENEWAL_WINDOW'] || '6').to_i.months
 
     config.secret_key_base = "iamonlyherefordevisewhenraketasksarecalled" if apply_dummy_secret_key?
+
+    config.email_test_address = ENV["WCRS_EMAIL_TEST_ADDRESS"] || "waste-carriers@example.com"
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,19 +36,25 @@ Registrations::Application.configure do
   config.assets.debug = true
 
   # Sending e-mails is required for user management and registration e-mails
-  use_https_in_emails = config.waste_exemplar_frontend_url.exclude?('localhost')
-  config.action_mailer.default_url_options = { host: config.subdomain, protocol: use_https_in_emails ? 'https' : 'http' }
+  config.action_mailer.default_url_options = { host: config.subdomain, protocol: 'http' }
 
   # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
+
+  # Default settings are for mailcatcher
   config.action_mailer.smtp_settings = {
-    address: ENV["WCRS_EMAIL_HOST"],
-    port: ENV["WCRS_EMAIL_PORT"]
+    user_name: ENV["WCRS_EMAIL_USERNAME"],
+    password: ENV["WCRS_EMAIL_PASSWORD"],
+    domain: config.subdomain,
+    address: ENV["WCRS_EMAIL_HOST"] || "localhost",
+    port: ENV["WCRS_EMAIL_PORT"] || 1025,
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   config.action_controller.asset_host = config.subdomain
-  config.action_mailer.asset_host = "#{use_https_in_emails ? 'https' : 'http'}://#{config.subdomain}"
+  config.action_mailer.asset_host = "http://#{config.subdomain}"
 
   # Overriding 'Done' URL for development
   #config.waste_exemplar_end_url = "https://www.gov.uk/done/waste-carrier-or-broker-registration"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,17 +78,17 @@ Registrations::Application.configure do
   # can still be viewed in emails. See
   # http://stackoverflow.com/questions/6152231/is-there-a-ruby-library-gem-that-will-generate-a-url-based-on-a-set-of-parameter for an explanation of the problem we faced and hopefully (!) the solution
   config.action_controller.asset_host = config.subdomain
-  config.action_mailer.asset_host = "#{'https'}://#{config.subdomain}"
+  config.action_mailer.asset_host = "https://#{config.subdomain}"
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :user_name => ENV["WCRS_EMAIL_USERNAME"],
-    :password => ENV["WCRS_EMAIL_PASSWORD"],
-    :domain => config.subdomain,
-    :address => ENV["WCRS_EMAIL_HOST"],
-    :port => ENV["WCRS_EMAIL_PORT"],
-    :authentication => :plain,
-    :enable_starttls_auto => true
+    user_name: ENV["WCRS_EMAIL_USERNAME"],
+    password: ENV["WCRS_EMAIL_PASSWORD"],
+    domain: config.subdomain,
+    address: ENV["WCRS_EMAIL_HOST"],
+    port: ENV["WCRS_EMAIL_PORT"],
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   config.assets.precompile += %w(

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :email do
+  desc "Send a test email to confirm confirm setup is correct"
+  task test: :environment do
+    puts RegistrationMailer.test_email.deliver_now
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-393

This change updates the email configuration in the app for 3 different reasons

1. It brings the settings inline with the WEX and FRAE services so that the way we configure ActionMailer is consistent
2. That we default to using mailcatcher in our development environment, but that we also allow the ability to override it in order to test sending email with Sendgrid
3. We have added a rake task to allow us to quickly test if emails can be sent from the app once deployed