### PR TITLE
Fix missing assets by not setting asset_host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,12 +74,6 @@ Registrations::Application.configure do
   # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false
 
-  # Ensures images included in emails that originate from our assest folder and pipepline
-  # can still be viewed in emails. See
-  # http://stackoverflow.com/questions/6152231/is-there-a-ruby-library-gem-that-will-generate-a-url-based-on-a-set-of-parameter for an explanation of the problem we faced and hopefully (!) the solution
-  config.action_controller.asset_host = config.subdomain
-  config.action_mailer.asset_host = "https://#{config.subdomain}"
-
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     user_name: ENV["WCRS_EMAIL_USERNAME"],


### PR DESCRIPTION
Having deployed the app to our AWS environment in production mode we found that 2 assets which are set as background images in the footer by the GOV.UK template would error and not display.

When we checked the error, it was because the url set for them was whatever was defined as the default for config.subdomain, even if an ENV VAR had been set. SO in this case it had set the link as https://localhost:3000.

We don't understand why it was using the default, even though a value had been set in the env var. Also when we added for debug purposes the call `asset_path('images/govuk-crest-2x.png')` it would display with the full path using the subdomain we had actually set.

Specifically the calls are made in govuk-template-css.erb in the govuk template gem

```css
  background-image: url(<%= asset_path 'images/govuk-crest-2x.png' %>);
```

When comparing and contrasting with other services we spotted that in `production.rb` it was setting the asset_host for the controllers and mailers, something not done in other services. We also couldn't understand the issue it was supposedly solving after reading https://stackoverflow.com/q/6152231/6117745. However deleting the lines that set the asset_host in production solved the problem, without seeming to have any other detrimental effects.

Hence we are making this change.