### PR TITLE
Add rake task to test mongodb connection

### DIFF
--- a/lib/tasks/connection.rake
+++ b/lib/tasks/connection.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :mongoid do
+    desc "Test the connection to MongoDb"
+    task connection: :environment do
+      puts "Mongoid configuration set? #{Mongoid::Config.configured?}"
+      puts "Connection to MongoDb working? #{connected?}"
+    end
+
+    def connected?
+      client = Mongoid::Clients.default
+      client.database.collections.length
+      true
+    rescue StandardError => e
+      puts e.message
+      false
+    end
+  end
+end


### PR DESCRIPTION
It can be useful when debugging issues in a new environment to be able to quickly test if the app can connect to the services it uses.

This adds one such test which is to check we can connect to MongoDb.