### PR TITLE
Remove hard coded use of service email values

### DIFF
--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -2,10 +2,6 @@ class RegistrationMailer < ActionMailer::Base
   helper :application
   helper :registrations
 
-  # This line should have set the default from name, but didnt in testing,
-  # as such from_address variables were created to pass in the email name
-  #default :from => "\"EA Waste Carriers\" <registrations@wastecarriersregistration.service.gov.uk>"
-
   def welcome_email(user, registration)
     @user = user
     @url = Rails.configuration.subdomain

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = '"Waste Carriers Service" <registrations@wastecarriersregistration.service.gov.uk>'
+  config.mailer_sender = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
When we send emails from non-production environments we are no longer using the production sendgrid details. As such this means if we were to continue to use 'registrations@wastecarriersregistration.service.gov.uk' as our from address it would be rejected by email clients such as Gmail because it does not match the DMARC policy set against it.

Therefore we have to specify a different email address. However in testing we found issues and realised that though we had an env var for this kind of information, the production details were still hardcoded into the Devise initializer.

This change removes it, and a no longer useful comment.