### PR TITLE
Do not raise error on Mongoid document not found

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -24,3 +24,5 @@ production:
       uri: <%= ENV['WCRS_REGSDB_URI'] %>
     users:
       uri: <%= ENV['WCRS_USERSDB_URI'] %>
+  options:
+    raise_not_found_error: false


### PR DESCRIPTION
Spotted when the app was deployed that if you did something like try to reset your password or resend your confirmation email, if the user was not found an error would be raised (causing a 404 in the app).

In essence this is a way of enumeration i.e. through repeated attempts to do this you can confirm whether an account exists by whether the action completes or causes an error.

Hence this change updates the mongoid configuration so document not found errors do not raise exceptions in production.