### PR TITLE
Add rake task to purge both databases

### DIFF
--- a/lib/tasks/purge_all.rake
+++ b/lib/tasks/purge_all.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :mongoid do
+
+    desc "Drop all collections in all databases, including indexes."
+    task purge_all: :environment do
+      Mongoid::Clients.default.database.collections.each(&:drop)
+      Mongoid::Clients.with_name("users").database.collections.each(&:drop)
+    end
+
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-449

To allow us to run our acceptance tests against an environment and get reproducible results we need to be able to reset and re-seed the databases before each run.

Now we can do this locally using the rake commands and database scripts, but this is not so easy in our actual environments as you first need to be able to ssh in to the back end servers.

One of the rake commands is `mongoid:purge` however after checking it out it only purges the default client (in our case waste-carriers). So to support this goal we have added a new rake task that allows us to purge both databases.