### PR TITLE
Assisted digital renewals are routed incorrectly

### DIFF
--- a/app/models/concerns/can_be_renewed.rb
+++ b/app/models/concerns/can_be_renewed.rb
@@ -41,6 +41,10 @@ module CanBeRenewed
     "#{Rails.configuration.renewals_service_url}#{regIdentifier}"
   end
 
+  def back_office_renewals_url
+    "#{Rails.configuration.back_office_renewals_url}#{regIdentifier}"
+  end
+
   private
 
   def add_validation_error(key, error_id)

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -208,7 +208,7 @@
                   <li><%= link_to t('form.payment_status_button_label'), paymentstatus_url(reg.uuid), id: "paymentStatus#{regCount}" %></li>
                 <% end %>
                 <% if reg.can_renew? %>
-                  <li><%= link_to t('form.renew_button_label'), reg.renewals_url %></li>
+                  <li><%= link_to t('form.renew_button_label'), reg.back_office_renewals_url %></li>
                 <% end %>
                 <% if reg.can_request_copy_cards?(current_agency_user) %>
                   <li><%= link_to t('form.addCopyCards_button_label'), order_copy_cards_path(reg.uuid) %></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,6 +67,7 @@ module Registrations
     config.waste_exemplar_addresses_url = ENV['WCRS_OS_PLACES_DOMAIN'] || 'http://localhost:8005'
 
     config.renewals_service_url = "#{ENV['WCRS_RENEWALS_DOMAIN'] || 'http://localhost:3000'}/fo/renew/"
+    config.back_office_renewals_url = "#{ENV['WCRS_BACK_OFFICE_DOMAIN'] || 'http://localhost:8001'}/bo/renew/"
 
     config.waste_exemplar_frontend_url = ENV['WCRS_FRONTEND_DOMAIN'] || 'http://localhost:3000'
     config.waste_exemplar_frontend_admin_url = ENV['WCRS_FRONTEND_ADMIN_DOMAIN'] || 'http://localhost:3000'

--- a/spec/models/concerns/can_be_renewed.rb
+++ b/spec/models/concerns/can_be_renewed.rb
@@ -127,4 +127,21 @@ shared_examples_for "can_be_renewed" do
       expect(subject.renewals_url).to eq("http://localhost:3000/renew/CBDU1")
     end
   end
+
+  describe "#back_office_renewals_url" do
+    before do
+      allow(Rails.configuration).to receive(:back_office_renewals_url).and_return("http://localhost:8001/bo/renew/")
+    end
+
+    subject do
+      registration = described_class.ctor
+      registration.regIdentifier = "CBDU1"
+      registration
+    end
+
+    it "returns the configured url with the registration number appended to the end" do
+      subject.tier = "LOWER"
+      expect(subject.back_office_renewals_url).to eq("http://localhost:8001/bo/renew/CBDU1")
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-448

In the existing registrations backend, it's possible to search for a registration and then select the Renew Registration option (if it's in the renewal window).

This should route to the back office /bo/renew/<registration_number> but at the moment routes to /fo/renew/<registration_number>.