### PR TITLE
Fix broken logic for renewals holding page

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,7 @@ module Registrations
     config.waste_exemplar_services_admin_url = ENV['WCRS_SERVICES_ADMIN_DOMAIN'] || 'http://localhost:8004'
     config.waste_exemplar_addresses_url = ENV['WCRS_OS_PLACES_DOMAIN'] || 'http://localhost:8005'
 
-    config.renewals_service_url = "#{ENV['WCRS_RENEWALS_DOMAIN'] || 'http://localhost:3000'}/fo/renew/"
+    config.renewals_service_url = "#{ENV['WCRS_RENEWALS_DOMAIN'] || 'http://localhost:3000'}/renew/"
     config.back_office_renewals_url = "#{ENV['WCRS_BACK_OFFICE_DOMAIN'] || 'http://localhost:8001'}/bo/renew/"
 
     config.waste_exemplar_frontend_url = ENV['WCRS_FRONTEND_DOMAIN'] || 'http://localhost:3000'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-456

Spotted as we came to prep the frontend for production release that the logic around where to go once a user has entered a digital registration number in the renew registration page was broken.

Basically the logic was just adding `/fo/renew/{ID}` to the end of whatever value was held in `WCRS_RENEWALS_DOMAIN`.

Locally this is fine because the front-office sits on a completely different domain to the frontend (localhost:300 vs localhost:3002). In production though we have to set this value to the external domain, which is the same for both of them.

Hence this means in production we would always be directing users to the frontend, even though we're not ready to do this until 19 September.

This change amends the logic. Now if `WCRS_RENEWALS_DOMAIN`. is set to just the domain, the frontend holding page will be used. If `WCRS_RENEWALS_DOMAIN` is the domain plus "/fo" then it will actually direct users to the front office.