### PR TITLE
Update renewal hold fix to not mess with env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,16 @@ module Registrations
       true
     end
 
+    def renewal_service_url
+      base_url = ENV['WCRS_RENEWALS_DOMAIN'] || 'http://localhost:3000'
+      path = if ENV['WCRS_HOLD_RENEWALS']
+        '/renew/'
+      else
+        '/fo/renew/'
+      end
+      "#{base_url}#{path}"
+    end
+
     config.time_zone = "Europe/London"
 
     # Custom directories with classes and modules you want to be autoloadable.
@@ -66,7 +76,7 @@ module Registrations
     config.waste_exemplar_services_admin_url = ENV['WCRS_SERVICES_ADMIN_DOMAIN'] || 'http://localhost:8004'
     config.waste_exemplar_addresses_url = ENV['WCRS_OS_PLACES_DOMAIN'] || 'http://localhost:8005'
 
-    config.renewals_service_url = "#{ENV['WCRS_RENEWALS_DOMAIN'] || 'http://localhost:3000'}/renew/"
+    config.renewals_service_url = renewal_service_url
     config.back_office_renewals_url = "#{ENV['WCRS_BACK_OFFICE_DOMAIN'] || 'http://localhost:8001'}/bo/renew/"
 
     config.waste_exemplar_frontend_url = ENV['WCRS_FRONTEND_DOMAIN'] || 'http://localhost:3000'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-456

The previous version of this fix [PR 158](https://github.com/DEFRA/waste-carriers-frontend/pull/158) required us to amend the value held in WCRS_RENEWALS_DOMAIN. However realised after the fact this could effect the other apps.

So this update gives us a solution that does not require messing with the env var WCRS_RENEWALS_DOMAIN. as it currently is in production.