### PR TITLE
Fix renewals url for back office

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,12 +41,12 @@ module Registrations
       true
     end
 
-    def renewal_service_url
+    def renewal_service_url(app_path)
       base_url = ENV['WCRS_RENEWALS_DOMAIN'] || 'http://localhost:3000'
       path = if ENV['WCRS_HOLD_RENEWALS']
         '/renew/'
       else
-        '/fo/renew/'
+        "/#{app_path}/renew/"
       end
       "#{base_url}#{path}"
     end
@@ -76,8 +76,8 @@ module Registrations
     config.waste_exemplar_services_admin_url = ENV['WCRS_SERVICES_ADMIN_DOMAIN'] || 'http://localhost:8004'
     config.waste_exemplar_addresses_url = ENV['WCRS_OS_PLACES_DOMAIN'] || 'http://localhost:8005'
 
-    config.renewals_service_url = renewal_service_url
-    config.back_office_renewals_url = "#{ENV['WCRS_BACK_OFFICE_DOMAIN'] || 'http://localhost:8001'}/bo/renew/"
+    config.renewals_service_url = renewal_service_url("fo")
+    config.back_office_renewals_url = renewal_service_url("bo")
 
     config.waste_exemplar_frontend_url = ENV['WCRS_FRONTEND_DOMAIN'] || 'http://localhost:3000'
     config.waste_exemplar_frontend_admin_url = ENV['WCRS_FRONTEND_ADMIN_DOMAIN'] || 'http://localhost:3000'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-456

Spotted that the renew registration link in the back office still got you through to the renewals service. This change rectifies that.