### PR TITLE
Fix missing GOV.UK logo in emails

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,0 +1,19 @@
+module EmailHelper
+
+  # This ensures that an images we need to display in an email are shown by
+  # adding them as attachments rather than exposing them as links to the
+  # service. We have found this a more reliable method and is the same used as
+  # in WEX and FRAE
+  def email_image_tag(image, **options)
+    path = "app/assets/images/#{image}"
+
+    full_path = Rails.root.join path
+
+    unless File.exist? full_path
+      full_path = "#{path}"
+    end
+
+    attachments[image] = File.read full_path
+    image_tag attachments[image].url, **options
+  end
+end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -1,6 +1,7 @@
 class RegistrationMailer < ActionMailer::Base
   helper :application
   helper :registrations
+  add_template_helper(EmailHelper)
 
   def welcome_email(user, registration)
     @user = user

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/app/views/registration_mailer/account_already_confirmed_email.html.erb
+++ b/app/views/registration_mailer/account_already_confirmed_email.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/app/views/registration_mailer/awaitingConvictionsCheck_email.html.erb
+++ b/app/views/registration_mailer/awaitingConvictionsCheck_email.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/app/views/registration_mailer/awaitingPayment_email.html.erb
+++ b/app/views/registration_mailer/awaitingPayment_email.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/app/views/registration_mailer/welcome_email.html.erb
+++ b/app/views/registration_mailer/welcome_email.html.erb
@@ -19,7 +19,7 @@
       <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
         <tr>
           <td width="100%" bgcolor="#0b0c0c" valign="middle">
-            <%= image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
+            <%= email_image_tag("govuk_logotype_email.png", {:alt => 'GOV.UK', :border => '0'}) %>
           </td>
         </tr>
       </table>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -259,3 +259,14 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 end
+
+# We need to include the email_image_tag() in our Devise custom mailer views
+# however we don't have a Registrations_Mailer.rb that we can call
+# add_template_helper() in.
+# The solution appears to be to add this piece of custom config in the Devise
+# initializer
+# https://groups.google.com/d/msg/plataformatec-devise/ZKo9EcgZxGA/8wyd0C8nCwAJ
+# https://github.com/plataformatec/devise/wiki/How-To:-Create-custom-layouts#application--devise-config
+Rails.application.config.to_prepare do
+  Devise::Mailer.helper :email
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-458

We have spotted that the GOV.UK logo which makes up part of the header in emails is not shown. This needs to display to help give users confidence that the email is from a reputable source.

We believe https://github.com/DEFRA/waste-carriers-frontend/pull/152 is to blame for why it is no longer appearing, but we also know just adding back in the deleted code will cause issues elsewhere.

Hence this change copies the way Waste Exemptions includes images in emails, by instead adding it as an attachment and having the email link to that.