### PR TITLE
Remove change account email from admin screen

### DIFF
--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -193,7 +193,6 @@
               <li><span><%= t('.actions_heading') %></span><li>
               <% if reg.can_view_certificate? %><li><%= link_to t('registrations.form.view_button_label'), view_path(reg.uuid), target: '_blank' %></li><% end %>
               <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_button_label'), edit_path(reg.uuid, edit_process: RegistrationsController::EditMode::EDIT) %></li><% end %>
-              <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_account_email_label'), edit_account_email_path(reg.uuid) %></li><% end %>
               <% if reg.can_be_deleted?(current_agency_user) %><li><%= link_to t('form.deregister_button_label'), confirmDelete_path(reg.uuid) %></li><% end %>
               <% if reg.is_revocable?(current_agency_user) %><li><%= link_to t('registrations.form.revoke_button_label'), revoke_path(reg.uuid), id: "revokeRegistration#{regCount}" %></li><% end %>
               <% if reg.is_unrevocable?(current_agency_user) %><li><%= link_to t('registrations.form.unrevoke_button_label'), unrevoke_path(reg.uuid) %></li><% end %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-465

It has been agreed as a feature the change account email function is potentially risky, as it would have the ability to move all registrations to a new account, something users might not be aware of based on the current design.

As it is, it seems to be just causing problems due to its ability to orphan registrations if the email contains capital letters or the account is linked to more than one registration.

Therefore in a meeting on Sep 14 Chris Jackson the team lead agreed with the team that the link should be removed.