### PR TITLE
Display account_email for registrations in NCCC dashboard

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1612,4 +1612,10 @@ class Registration < Ohm::Model
     finance_details.first.orders.to_a.last
   end
 
+  # This is just true for matching external users, not agency users or other backend users
+  def account_email_has_no_matching_user?
+    return true if accountEmail.blank?
+    return false if User.where(email: accountEmail).count.positive?
+    true
+  end
 end

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -155,6 +155,10 @@
               <% else %>
                 <%= t '.no_account_email' %>
               <% end %>
+              <% if reg.account_email_has_no_matching_user? %>
+                <br>
+                <em><%= t '.no_matching_account' %></em>
+              <% end %>
               </p>
             </li>
           </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1134,6 +1134,7 @@ en:
       aside_heading: "Other functions"
       company_name: "Name"
       no_account_email: "none"
+      no_matching_account: "No matching user found"
       registration: "registration"
       record: "record"
       actions_heading: "Actions"

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -224,4 +224,27 @@ describe Registration do
 
     it_behaves_like 'an acceptance step'
   end
+
+  describe "account_email_has_no_matching_user?" do
+    context "when there is a matching account" do
+      before do
+        user = User.create(email: "thisexists@example.com", password: "Secret123")
+        subject.accountEmail = user.email
+      end
+
+      it "returns false" do
+        expect(subject.account_email_has_no_matching_user?).to eq(false)
+      end
+    end
+
+    context "when there is no matching account" do
+      before do
+        subject.accountEmail = "thisdoesnotexist@example.com"
+      end
+
+      it "returns false" do
+        expect(subject.account_email_has_no_matching_user?).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-477

When we list registrations for logged-in agency users, we should also include the account_email. This means that a backend user can quickly tell who a registration belongs to, and therefore what email address must be used to log in and renew or otherwise modify it.