### PR TITLE
Inaccurate "new or renew registration" link in existing backend

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1541,7 +1541,7 @@ en:
       company_number_info: "An 8 digit number, or 2 letters followed by a 6 digit number.  Find it on a letter from <a href=\"%{ch_url}\" target=\"_blank\" rel=\"external\">Companies House</a> or HMRC tax office."
     current_user:
       change_password: "Change password"
-      new_registration: "New or renew registration"
+      new_registration: "New registration"
       registrations_export: "Registrations export"
       payments_export: "Payments export"
       copy_cards_export: "Copy cards export"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-480

Logged-in backend users used to see a link to "New or renew registration". This was true when we were processing IR renewals but is now incorrect. This commit fixes the link text to just be "New registration", which is what that link actually leads to.