### PR TITLE
Fix some business type content in declaration

### DIFF
--- a/app/views/registrations/_smartanswers_display.html.erb
+++ b/app/views/registrations/_smartanswers_display.html.erb
@@ -1,7 +1,13 @@
 <ul id='smartanswers_display'>
   <% unless r.businessType.blank? %>
     <li>
-      <%= t '.business_type', :businessType => t('business_types.' + r.businessType).downcase %>
+      <% if r.businessType == "overseas" %>
+        <%= t '.overseas_business_type' %>
+      <% elsif r.businessType == "soleTrader" %>
+        <%= t '.sole_trader_business_type' %>
+      <% else %>
+        <%= t '.business_type', :businessType => t('business_types.' + r.businessType).downcase %>
+      <% end %>
     </li>
   <% end %>
   <% unless r.otherBusinesses.blank? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1374,6 +1374,8 @@ en:
       title_unrevoke: "UnRevoke registration"
     smartanswers_display:
       business_type: "You are a %{businessType}"
+      overseas_business_type: "You are based overseas"
+      sole_trader_business_type: "You are an individual or sole trader"
       construction_demolition_no: "You never deal with construction or demolition waste"
       construction_demolition_yes: "You deal with construction or demolition waste"
       only_deal_with_no: "You deal with waste other than animal by-products, waste from a mine or quarry, or farm or agricultural waste"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-511

We previously resolved the missing translation error for overseas companies in PR #168. However when we then checked the content that got displayed in the declaration page (when editing a registration) what was displayed didn't really make sense for some business types

> You are a overseas
> You are a individual or sole trader

So this additional fix puts in some extra logic to allow us to show an alternative for the problem business types

> You are based overseas
> You are an individual or sole trader