### PR TITLE
Update default renewal window to match current

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -222,7 +222,7 @@ module Registrations
 
     # Upper tier registrations can be renewed starting a given time period (e.g.
     # 6 months) before their expiration date.
-    config.registration_renewal_window = (ENV['WCRS_REGISTRATION_RENEWAL_WINDOW'] || '6').to_i.months
+    config.registration_renewal_window = (ENV['WCRS_REGISTRATION_RENEWAL_WINDOW'] || '3').to_i.months
 
     config.secret_key_base = "iamonlyherefordevisewhenraketasksarecalled" if apply_dummy_secret_key?
 

--- a/spec/models/concerns/can_be_renewed.rb
+++ b/spec/models/concerns/can_be_renewed.rb
@@ -38,10 +38,6 @@ shared_examples_for "can_be_renewed" do
     end
 
     context "when the registration expires outside the renewal window" do
-      before do
-        allow(Rails.configuration).to receive(:registration_renewal_window).and_return(3.months)
-      end
-
       it "cannot be renewed" do
         expiry_date = (3.months.from_now + 2.day).to_date
         subject.expires_on = date_to_utc_milliseconds(expiry_date)


### PR DESCRIPTION
When the service was updated and re-shipped on September 12 2018 we also updated the renewal window to 3 months instead of 6. This was in preparation for launch of the renewals service on the 19th.

However spotted that the default was still at 6 months.

This change updates the default to match what we now use, and because of this change we can remove an unnecessary stub.