### PR TITLE
Add standard rubocop config to project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,93 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  # Cop names are not displayed in offense messages by default. We find it
+  # useful to include this information so we can use it to investigate what the
+  # fix may be.
+  DisplayCopNames: true
+  # Style guide URLs are not displayed in offense messages by default. Again we
+  # find it useful to go straight to the documentation for a rule when
+  # investigating what the fix may be.
+  DisplayStyleGuide: true
+  Include:
+    - "**/*.gemspec"
+    - "**/*.rake"
+    - "**/*.rb"
+    - "**/Gemfile"
+    - "**/Rakefile"
+    - "**/config.ru"
+  Exclude:
+    # config contains standard files created when Rails is initialised and
+    # therefore they should be left as is
+    - "**/config/**/*"
+    # bin contains standard files created when Rails is initialised and
+    # therefore they should be left as is
+    - "**/bin/*"
+    # locally when we run rubocop it ignores the vendor folder but when running
+    # in Travis-CI it seems to include. This will stop this from happening
+    - "**/vendor/**/*"
+    ## schema.rb is generated automatically based on migrations, so leave as is
+    - "**/db/schema.rb"
+
+# It is our opinion that code is easier to read if a white space is
+# permitted between the initial declaration and the first statement. Ditto the
+# last statement and the closing tag.
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+# We felt as a team that the default size of 15 was too low, and blocked what to
+# us are sound methods which would not add any value if broken up, for example
+# composer type methods. Therefore we agreed to up the score to 30 to allow for
+# these types of methods
+Metrics/AbcSize:
+  Max: 30
+
+# We don't feel it makes sense to split specs and factories over multiple files,
+# or when in a context be forced to try and come up with slightly different ones
+# in order to reduce the block length. Hence we exclude specs and factories from
+# this rule.
+# Shared examples are the same as specs, but don't have the _spec.rb extension
+# hence they are listed separately
+Metrics/BlockLength:
+  Exclude:
+    - "**/spec/**/*_spec.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/spec/support/shared_examples/*.rb"
+
+# We believe the default 80 characters is too restrictive and that lines can
+# still be readable and maintainable when no more than 120 characters. This also
+# allows us to maximise our screen space.
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - "**/spec/**/*_spec.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/spec/support/shared_examples/*.rb"
+
+# We wish we were good enough to remain within the rubocop limit of 10 lines
+# however we often just seem to tip over by a few lines. Hence we have chosen
+# to bump it to 20.
+Metrics/MethodLength:
+  Max: 20
+
+# Spec files can be quite long, so we shouldn't be forced to break them up
+# if it doesn't make sense.
+Metrics/ModuleLength:
+  Exclude:
+    - "**/spec/**/*_spec.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/spec/support/shared_examples/*.rb"
+
+# As a web app, as long as the team commit to using well named classes for
+# controllers, models etc it should not be necessary to add top-level class
+# documentation.
+Style/Documentation:
+  Enabled: false
+
+# There are no relative performance improvements using '' over "", therefore we believe there is more
+# value in using "" for all strings irrespective of whether string interpolation is used
+Style/StringLiterals:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
We know that the project does not follow our current rubocop style conventions. However when working on changes we want those changes to abide by them.

Most editors have some form of inbuilt linting, so by adding this config those editors can take advantage of the config being there to highlight issues in the code being worked on.

We as the devs than can use this information to ensure what we add or change meets our current conventions. It also means where an editor doesn't have a config file to fall back on, its doesn't cause confusion by highlighting issues that are not consistent with our conventions.