### PR TITLE
Use NCCC default for AD accountEmail instead of individual emails

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -228,7 +228,7 @@ class RegistrationsController < ApplicationController
         # Only update the account email if not already set.  This allows users
         # who drop-off at payment, but use NCCC to make a payment, stay as
         # digital users.
-        @registration.accountEmail = current_agency_user.email
+        @registration.accountEmail = Rails.configuration.assisted_digital_account_email
       end
       @user = User.find_by_email(current_agency_user.email)
       agency_user_signed_in = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -234,5 +234,7 @@ module Registrations
     config.secret_key_base = "iamonlyherefordevisewhenraketasksarecalled" if apply_dummy_secret_key?
 
     config.email_test_address = ENV["WCRS_EMAIL_TEST_ADDRESS"] || "waste-carriers@example.com"
+
+    config.assisted_digital_account_email = ENV["WCRS_ASSISTED_DIGITAL_EMAIL"]
   end
 end

--- a/spec/controllers/registrations_spec.rb
+++ b/spec/controllers/registrations_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe RegistrationsController, :type => :controller do
+  let(:registration) { Registration.create }
+
+  describe "GET #account_mode" do
+    let(:default_email) { "default@example.com" }
+    before do
+      allow(Rails.configuration).to receive(:assisted_digital_account_email).and_return(default_email)
+    end
+
+    context "when an agency_user is signed in" do
+      let(:agency_user) { AgencyUser.create }
+      before do
+        allow_any_instance_of(RegistrationsController).to receive(:agency_user_signed_in?).and_return(true)
+        allow_any_instance_of(RegistrationsController).to receive(:current_agency_user).and_return(agency_user)
+        allow_any_instance_of(Registration).to receive(:initialize_sign_up_mode).and_return("sign_in")
+      end
+
+      it "assigns the default email to the accountEmail" do
+        get :account_mode, reg_uuid: registration.reg_uuid
+        expect(assigns(:registration).accountEmail).to eq(default_email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-482

Currently AD registrations set the accountEmail to the individual email of the agency_user. This means that these agency_users are treated as the account holder by the apps, and end up receiving email notifications about registrations they happened to register.

To stop this happening, we want to use a default shared inbox for AD registrations instead.