### PR TITLE
Fix specs by re-recording VCR cassettes

### DIFF
--- a/spec/models/companies_house_caller_spec.rb
+++ b/spec/models/companies_house_caller_spec.rb
@@ -133,7 +133,7 @@ describe CompaniesHouseCaller do
     end
 
     context 'voluntary arrangement' do
-      subject { CompaniesHouseCaller.new '04270505' }
+      subject { CompaniesHouseCaller.new '01618428' }
 
       it 'live response from Companies House (will fail when company changes status)', :vcr do
         expect(subject.status).to eq(:active)

--- a/spec/vcr/companies_house_caller_status/voluntary_arrangement_live_response_from_companies_house_will_fail_when_company_changes_status_.yml
+++ b/spec/vcr/companies_house_caller_status/voluntary_arrangement_live_response_from_companies_house_will_fail_when_company_changes_status_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.companieshouse.gov.uk/company/04270505
+    uri: https://api.companieshouse.gov.uk/company/01618428
     body:
       encoding: US-ASCII
       string: ''
@@ -21,11 +21,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 06 Feb 2018 14:28:45 GMT
+      - Tue, 19 Mar 2019 16:38:57 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1655'
+      - '1564'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -47,19 +47,19 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '595'
+      - '596'
       X-Ratelimit-Reset:
-      - '1517927615'
+      - '1553013748'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"registered_office_address":{"postal_code":"SR8 2HY","locality":"Peterlee","address_line_2":"North
-        West Industrial Estate","address_line_1":"2 Cook Way","region":"Co Durham"},"has_been_liquidated":false,"accounts":{"next_made_up_to":"2018-03-31","next_accounts":{"overdue":false,"period_end_on":"2018-03-31","period_start_on":"2017-04-01","due_on":"2018-12-31"},"overdue":false,"next_due":"2018-12-31","accounting_reference_date":{"month":"03","day":"31"},"last_accounts":{"period_end_on":"2017-03-31","made_up_to":"2017-03-31","period_start_on":"2016-04-01","type":"full"}},"jurisdiction":"england-wales","company_name":"TSF
-        RETAIL SOLUTIONS LIMITED","type":"ltd","last_full_members_list_date":"2015-08-15","sic_codes":["43320","43390","43999"],"date_of_creation":"2001-08-15","company_number":"04270505","undeliverable_registered_office_address":false,"has_insolvency_history":true,"etag":"a47700a2d099085f5f6096387d0b5ef584bc269b","company_status":"active","has_charges":true,"previous_company_names":[{"effective_from":"2001-11-01","ceased_on":"2006-06-01","name":"MOMS
-        LIMITED"},{"name":"BLAZECLEAN LIMITED","effective_from":"2001-08-15","ceased_on":"2001-11-01"}],"confirmation_statement":{"last_made_up_to":"2017-08-15","next_made_up_to":"2018-08-15","next_due":"2018-08-29","overdue":false},"links":{"self":"/company/04270505","filing_history":"/company/04270505/filing-history","officers":"/company/04270505/officers","charges":"/company/04270505/charges","insolvency":"/company/04270505/insolvency","persons_with_significant_control":"/company/04270505/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+      string: '{"jurisdiction":"england-wales","etag":"efb72a189e07662facd6d1f872a6edef8388edb5","date_of_creation":"1982-03-01","accounts":{"next_made_up_to":"2019-03-27","next_due":"2019-12-27","overdue":false,"last_accounts":{"made_up_to":"2018-03-24","period_end_on":"2018-03-24","type":"full","period_start_on":"2017-03-26"},"accounting_reference_date":{"day":"27","month":"03"},"next_accounts":{"period_end_on":"2019-03-27","overdue":false,"period_start_on":"2018-03-25","due_on":"2019-12-27"}},"last_full_members_list_date":"2015-07-30","company_number":"01618428","has_charges":true,"company_name":"NEW
+        LOOK RETAILERS LIMITED","registered_office_address":{"postal_code":"DT3 5HJ","address_line_1":"New
+        Look House","address_line_2":"Mercery Road","locality":"Weymouth","region":"Dorset"},"type":"ltd","sic_codes":["47710","47721","47722","47910"],"company_status":"voluntary-arrangement","has_insolvency_history":true,"previous_company_names":[{"effective_from":"1982-03-01","name":"NEW
+        LOOK WHOLESALERS LIMITED","ceased_on":"1987-06-08"}],"undeliverable_registered_office_address":false,"confirmation_statement":{"overdue":false,"next_due":"2019-08-13","next_made_up_to":"2019-07-30","last_made_up_to":"2018-07-30"},"links":{"self":"/company/01618428","filing_history":"/company/01618428/filing-history","officers":"/company/01618428/officers","charges":"/company/01618428/charges","persons_with_significant_control":"/company/01618428/persons-with-significant-control","insolvency":"/company/01618428/insolvency"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Tue, 06 Feb 2018 14:28:02 GMT
+  recorded_at: Tue, 19 Mar 2019 16:38:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/manually_expired/companies_house/proposal_to_strike_off.yml
+++ b/spec/vcr/manually_expired/companies_house/proposal_to_strike_off.yml
@@ -21,11 +21,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 18 Jan 2018 21:23:43 GMT
+      - Tue, 19 Mar 2019 15:41:18 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1198'
+      - '1171'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -47,9 +47,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '580'
+      - '597'
       X-Ratelimit-Reset:
-      - '1516310778'
+      - '1553010167'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -57,8 +57,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"registered_office_is_in_dispute":false,"has_charges":false,"undeliverable_registered_office_address":false,"type":"ltd","company_status":"active","links":{"self":"/company/10761329","persons_with_significant_control":"/company/10761329/persons-with-significant-control","filing_history":"/company/10761329/filing-history","officers":"/company/10761329/officers"},"has_insolvency_history":false,"company_number":"10761329","company_name":"WASTE
-        AWAY SERVICES LTD","confirmation_statement":{"next_due":"2018-05-22","overdue":false,"next_made_up_to":"2018-05-08"},"accounts":{"next_due":"2019-02-09","accounting_reference_date":{"month":"05","day":"31"},"next_accounts":{"due_on":"2019-02-09","period_start_on":"2017-05-09","overdue":false,"period_end_on":"2018-05-31"},"last_accounts":{"type":"null"},"next_made_up_to":"2018-05-31","overdue":false},"sic_codes":["96090"],"registered_office_address":{"locality":"Hoddesdon","country":"United
-        Kingdom","address_line_1":"72 Old Essex Road","postal_code":"EN11 0AE"},"etag":"395a26e068aad0ceab8d335a43e6452b6d4b4726","jurisdiction":"england-wales","date_of_creation":"2017-05-09","company_status_detail":"active-proposal-to-strike-off","can_file":true}'
+        AWAY SERVICES LTD","confirmation_statement":{"next_due":"2019-05-22","last_made_up_to":"2018-05-08","next_made_up_to":"2019-05-08","overdue":false},"accounts":{"next_accounts":{"overdue":true,"period_start_on":"2017-05-09","period_end_on":"2018-05-31","due_on":"2019-02-09"},"last_accounts":{"type":"null"},"next_due":"2019-02-09","accounting_reference_date":{"day":"31","month":"05"},"next_made_up_to":"2018-05-31","overdue":true},"sic_codes":["96090"],"registered_office_address":{"locality":"Hoddesdon","address_line_1":"72
+        Old Essex Road","country":"United Kingdom","postal_code":"EN11 0AE"},"etag":"c93515bd86e73a2584d295b3f7be4c035eac275b","jurisdiction":"england-wales","date_of_creation":"2017-05-09","can_file":true}'
     http_version: 
-  recorded_at: Thu, 18 Jan 2018 21:23:43 GMT
+  recorded_at: Tue, 19 Mar 2019 15:41:18 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/manually_expired/companies_house/voluntary_arrangement.yml
+++ b/spec/vcr/manually_expired/companies_house/voluntary_arrangement.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.companieshouse.gov.uk/company/04270505
+    uri: https://api.companieshouse.gov.uk/company/01618428
     body:
       encoding: US-ASCII
       string: ''
@@ -21,11 +21,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 18 Jan 2018 16:10:02 GMT
+      - Tue, 19 Mar 2019 16:35:43 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1655'
+      - '1564'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -47,19 +47,19 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '598'
+      - '595'
       X-Ratelimit-Reset:
-      - '1516292001'
+      - '1553013442'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"registered_office_address":{"postal_code":"SR8 2HY","locality":"Peterlee","address_line_2":"North
-        West Industrial Estate","address_line_1":"2 Cook Way","region":"Co Durham"},"has_been_liquidated":false,"accounts":{"next_made_up_to":"2018-03-31","next_accounts":{"overdue":false,"period_end_on":"2018-03-31","period_start_on":"2017-04-01","due_on":"2018-12-31"},"overdue":false,"next_due":"2018-12-31","accounting_reference_date":{"month":"03","day":"31"},"last_accounts":{"period_end_on":"2017-03-31","made_up_to":"2017-03-31","period_start_on":"2016-04-01","type":"full"}},"jurisdiction":"england-wales","company_name":"TSF
-        RETAIL SOLUTIONS LIMITED","type":"ltd","last_full_members_list_date":"2015-08-15","sic_codes":["43320","43390","43999"],"date_of_creation":"2001-08-15","company_number":"04270505","undeliverable_registered_office_address":false,"has_insolvency_history":true,"etag":"a47700a2d099085f5f6096387d0b5ef584bc269b","company_status":"active","has_charges":true,"previous_company_names":[{"effective_from":"2001-11-01","ceased_on":"2006-06-01","name":"MOMS
-        LIMITED"},{"name":"BLAZECLEAN LIMITED","effective_from":"2001-08-15","ceased_on":"2001-11-01"}],"confirmation_statement":{"last_made_up_to":"2017-08-15","next_made_up_to":"2018-08-15","next_due":"2018-08-29","overdue":false},"links":{"self":"/company/04270505","filing_history":"/company/04270505/filing-history","officers":"/company/04270505/officers","charges":"/company/04270505/charges","insolvency":"/company/04270505/insolvency","persons_with_significant_control":"/company/04270505/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+      string: '{"jurisdiction":"england-wales","etag":"efb72a189e07662facd6d1f872a6edef8388edb5","date_of_creation":"1982-03-01","accounts":{"next_made_up_to":"2019-03-27","next_due":"2019-12-27","overdue":false,"last_accounts":{"made_up_to":"2018-03-24","period_end_on":"2018-03-24","type":"full","period_start_on":"2017-03-26"},"accounting_reference_date":{"day":"27","month":"03"},"next_accounts":{"period_end_on":"2019-03-27","overdue":false,"period_start_on":"2018-03-25","due_on":"2019-12-27"}},"last_full_members_list_date":"2015-07-30","company_number":"01618428","has_charges":true,"company_name":"NEW
+        LOOK RETAILERS LIMITED","registered_office_address":{"postal_code":"DT3 5HJ","address_line_1":"New
+        Look House","address_line_2":"Mercery Road","locality":"Weymouth","region":"Dorset"},"type":"ltd","sic_codes":["47710","47721","47722","47910"],"company_status":"voluntary-arrangement","has_insolvency_history":true,"previous_company_names":[{"effective_from":"1982-03-01","name":"NEW
+        LOOK WHOLESALERS LIMITED","ceased_on":"1987-06-08"}],"undeliverable_registered_office_address":false,"confirmation_statement":{"overdue":false,"next_due":"2019-08-13","next_made_up_to":"2019-07-30","last_made_up_to":"2018-07-30"},"links":{"self":"/company/01618428","filing_history":"/company/01618428/filing-history","officers":"/company/01618428/officers","charges":"/company/01618428/charges","persons_with_significant_control":"/company/01618428/persons-with-significant-control","insolvency":"/company/01618428/insolvency"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Thu, 18 Jan 2018 16:09:58 GMT
+  recorded_at: Tue, 19 Mar 2019 16:35:43 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
It's a known issue with the VCR cassettes for companies house that edge cases like companies in voluntary arrangement won't remain in that state for long periods of time.

Recently when running the unit tests we got exactly that issue in the the previous example has now gone into administrtation.

So this change updates the specs and VCR to use a different company that is currently listed as being in Voluntary Arrangement.