### PR TITLE
Fix how mongoid is specified in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem 'rails', '4.2.10'
 gem 'airbrake', '~> 5.3'
 
 # We store user accounts (authentication with Devise) in a MongoDB database
-gem "mongoid", "~> 5.2"
+# This version of mongoid supports MongoDb 3.6
+gem "mongoid", "~> 5.2.0"
 
 # Using devise for authentication
 gem 'devise', '~> 3.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ DEPENDENCIES
   launchy (~> 2.4.2)
   monetize
   money-rails
-  mongoid (~> 5.2)
+  mongoid (~> 5.2.0)
   ohm (~> 3.0.0)
   passenger (~> 5.0, >= 5.0.30)
   poltergeist (~> 1.6.0)


### PR DESCRIPTION
In PR #204 (https://github.com/DEFRA/waste-carriers-frontend/pull/204) Dependabot attempted to update mongoid to 5.4.0. However on checking with our other WCR projects the version they are using is Mongoid 5.2.1.

The one difference between the projects was the difference in how the versioning was specified in the Gemfile. We want to keep the version of mongoid consistent across the projects because we are so dependant on it hence this change to bring the frontend in line with the Front office and Back office projects.