### PR TITLE
Update devise and reference in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'airbrake', '~> 5.3'
 gem "mongoid", "~> 5.2.0"
 
 # Using devise for authentication
-gem 'devise', '~> 3.4.1'
+gem "devise", ">= 4.4.3"
 
 # Using cancan for authorisation
 gem 'cancan', '~> 1.6.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     aws-healthcheck (1.0.1)
       rails (>= 3.0)
     backports (3.12.0)
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -118,12 +118,11 @@ GEM
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
-    devise (3.4.1)
+    devise (4.6.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 6.0)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
@@ -270,8 +269,9 @@ GEM
     rake (12.3.2)
     redic (1.5.0)
       hiredis
-    responders (2.2.0)
-      railties (>= 4.2.0, < 5.1)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -347,7 +347,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode_utils (1.4.0)
     vcr (4.0.0)
-    warden (1.2.6)
+    warden (1.2.7)
       rack (>= 1.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
@@ -381,7 +381,7 @@ DEPENDENCIES
   countries
   cucumber-rails (~> 1.6.0)
   database_cleaner (~> 1.7.0)
-  devise (~> 3.4.1)
+  devise (>= 4.4.3)
   dotenv-rails
   factory_girl_rails (~> 4.4.1)
   faker


### PR DESCRIPTION
This update to Devise fixes [CVE-2019-5421](https://github.com/plataformatec/devise/issues/4981) which is a moderate severity security vulnerability.

It also updates the way we specify the version in the Gemfile to make it consistent with how we do it in the WCR back office app.