### PR TITLE
Fix broken link to NI waste carriers service

### DIFF
--- a/app/views/register_in_northern_ireland/show.html.erb
+++ b/app/views/register_in_northern_ireland/show.html.erb
@@ -26,7 +26,7 @@
         <div id="register-text">
           <div class="text">
             <p><%= t '.paragraph_1' %></p>
-            <p><%= t '.paragraph_2' %> <a href="https://www.gov.uk/waste-carrier-or-broker-registration-northern-ireland/northern-ireland-environment-agency"><%= t(".service_link") %></a>.</p>
+            <p><%= t '.paragraph_2' %> <a href="https://www.gov.uk/waste-carrier-or-broker-registration-northern-ireland"><%= t(".service_link") %></a>.</p>
             <p><%= t '.paragraph_3' %></p>
           </div>
         </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-214

Was spotted during the testing of the new location pages in the frontend that the link to Northern Ireland no longer works (it 404's).

A quick check confirmed that they have changed the URL. This change updates the view to point to the correct URL for the service.