### PR TITLE
Add email interception and retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,7 @@ WCRS_REDIS_DB_URL="redis://127.0.0.1:6379"
 # Google Analytics
 WCRS_USE_GOOGLE_ANALYTICS=false
 WCRS_FRONTEND_GOOGLE_TAGMANAGER_ID=
+
+# Expose the data stored by the LastEmailCache. Only used in our acceptance
+# tests and should not be enabled in production.
+WCRS_USE_LAST_EMAIL_CACHE=true

--- a/app/controllers/last_email_controller.rb
+++ b/app/controllers/last_email_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LastEmailController < ApplicationController
+  def show
+    render json: LastEmailCache.instance.last_email_json
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -216,5 +216,9 @@ module Registrations
     config.email_test_address = ENV["WCRS_EMAIL_TEST_ADDRESS"] || "waste-carriers@example.com"
 
     config.assisted_digital_account_email = ENV["WCRS_ASSISTED_DIGITAL_EMAIL"]
+
+    # Expose the data stored by the LastEmailCache. Only used in our acceptance
+    # tests and should not be enabled in production.
+    config.use_last_email_cache = ENV["WCRS_USE_LAST_EMAIL_CACHE"] || false
   end
 end

--- a/config/initializers/last_email_cache.rb
+++ b/config/initializers/last_email_cache.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActionMailer::Base.register_interceptor(LastEmailCache)

--- a/config/initializers/last_email_cache.rb
+++ b/config/initializers/last_email_cache.rb
@@ -1,3 +1,22 @@
 # frozen_string_literal: true
 
-ActionMailer::Base.register_interceptor(LastEmailCache)
+# There is a reason for the additional `Rails.env == "test"` condition!
+# After many attempts trying to set whether last email cache is enabled or not
+# in our unit tests we realised that the initializers are called before any kind
+# of mocking/stubbing goes on in an RSpec test. So we would never be able to
+# control whether the interceptor is registered or not when testing.
+#
+# So next we looked at ignoring the interceptor and using either RSpec filters
+# or hooks to control the registering and unregistering of the interceptor.
+# However we hit an issue there as well. Registering the interceptor was fine,
+# but unregistering was only merged into ActionMailer in May 2018
+# (https://github.com/rails/rails/pull/32207).
+#
+# So to ensure the tests were clean and the interceptor removed when they
+# finished we were left with having to introduce a monkey patch. 😩
+#
+# This seemed overkill for what we wanted to achieve, hence this final solution
+# which is to always register the interceptor if we are running in "test".
+if Rails.configuration.use_last_email_cache || Rails.env == "test"
+  ActionMailer::Base.register_interceptor(LastEmailCache)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,15 @@ Registrations::Application.routes.draw do
 
   resources :registrations
 
+  # Expose the data stored by the LastEmailCache
+  # if Rails.configuration.use_last_email_cache
+  #   get "/last-email" => "last_email#show", :as => :last_email
+  # end
+  get "/last-email",
+      to: "last_email#show",
+      as: "last_email",
+      constraints: ->(_request) { Rails.configuration.use_last_email_cache }
+
   # routes for renewals and edits
   match "registrations/:uuid/edit" => 'registrations#edit', :via => [:get], :as => :edit
   match "registrations/:uuid/edit" => 'registrations#update', :via => [:post,:put,:patch]

--- a/lib/last_email_cache.rb
+++ b/lib/last_email_cache.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "singleton"
+require "json"
+
+class LastEmailCache
+  include Singleton
+
+  EMAIL_ATTRIBUTES = %i[date from to bcc cc reply_to subject].freeze
+
+  attr_accessor :last_email
+
+  def self.delivering_email(message)
+    instance.last_email = message
+  end
+
+  # This is necessary to properly test the service functionality
+  def reset
+    @last_email = nil
+  end
+
+  def last_email_json
+    return JSON.generate(error: "No emails sent.") unless last_email.present?
+
+    message_hash = {}
+    EMAIL_ATTRIBUTES.each do |attribute|
+      message_hash[attribute] = last_email.public_send(attribute)
+    end
+    message_hash[:body] = email_body
+    message_hash[:attachments] = last_email.attachments.map(&:filename)
+
+    JSON.generate(last_email: message_hash)
+  end
+
+  private
+
+  # If you've set multipart emails then you'll have both a text and a html
+  # version (determined by adding the relevant erb views). If you do so then
+  # `my_mail.parts.length` will equal 2. If however you only have the one then
+  # `parts` doesn't seem to get populated. To cater for this we have this
+  # method to grab the body content
+  # https://guides.rubyonrails.org/action_mailer_basics.html#sending-multipart-emails
+  def email_body
+    return last_email.body.to_s if last_email.parts.empty?
+
+    last_email.text_part.to_s
+  end
+end

--- a/spec/lib/last_email_cache_spec.rb
+++ b/spec/lib/last_email_cache_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe LastEmailCache do
+  subject(:instance) { described_class.instance }
+
+  describe "#last_email_json" do
+    let(:expected_attributes) { %w[date from to bcc cc reply_to subject body attachments] }
+
+    context "when the no emails have been sent" do
+      before(:each) { instance.reset }
+      let(:result) { instance.last_email_json }
+
+      it "returns a JSON string" do
+        expect(result).to be_a(String)
+        expect { JSON.parse(result) }.to_not raise_error
+      end
+
+      it "responds with an error message" do
+        parsed_result = JSON.parse(result)
+        expect(parsed_result.key?("error")).to eq(true)
+        expect(parsed_result["error"]).to eq("No emails sent.")
+      end
+    end
+
+    context "when an email has been sent" do
+      let(:result) { instance.last_email_json }
+      let(:recipient) { "test@example.com" }
+      before(:each) do
+        instance.reset
+        generate_test_email(recipient).deliver_now
+      end
+
+      it "returns a JSON string" do
+        expect(result).to be_a(String)
+        expect { JSON.parse(result) }.to_not raise_error
+      end
+
+      it "responds with the email as JSON" do
+        parsed_result = JSON.parse(result)
+        expect(parsed_result["last_email"].keys).to match_array(expected_attributes)
+        expect(parsed_result["last_email"]["to"]).to eq([recipient])
+      end
+    end
+
+    context "when multiple emails have been sent" do
+      let(:result) { instance.last_email_json }
+      let(:first_recipient) { "test@example.com" }
+      let(:second_recipient) { "joe.bloggs@example.com" }
+      before(:each) do
+        instance.reset
+        generate_test_email(first_recipient).deliver_now
+        generate_test_email(second_recipient).deliver_now
+      end
+
+      it "returns a JSON string" do
+        expect(result).to be_a(String)
+        expect { JSON.parse(result) }.to_not raise_error
+      end
+
+      it "responds with the most recent email as JSON" do
+        parsed_result = JSON.parse(result)
+        expect(parsed_result["last_email"].keys).to match_array(expected_attributes)
+        expect(parsed_result["last_email"]["to"]).to eq([second_recipient])
+      end
+    end
+  end
+end

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -5,12 +5,16 @@ require "spec_helper"
 RSpec.describe "Errors", type: :request do
   describe "GET /last-email" do
     context "when `Rails.configuration.use_last_email_cache` is \"true\"" do
-      before { allow(Rails.configuration).to receive(:use_last_email_cache).and_return(true) }
+      before do
+        allow(Rails.configuration).to receive(:use_last_email_cache).and_return(true)
+      end
 
-      it "returns the JSON value of the LastEmailCache" do
+      it "returns the JSON value of the LastEmailCache", inject_interceptor: LastEmailCache do
         generate_test_email("test@example.com").deliver_now
         get last_email_path
-        expect(response.body).to eq(LastEmailCache.instance.last_email_json)
+        result = JSON.parse(response.body)
+
+        expect(result["last_email"]["to"]).to eq(["test@example.com"])
       end
     end
 

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Errors", type: :request do
+  describe "GET /last-email" do
+    context "when `Rails.configuration.use_last_email_cache` is \"true\"" do
+      before { allow(Rails.configuration).to receive(:use_last_email_cache).and_return(true) }
+
+      it "returns the JSON value of the LastEmailCache" do
+        generate_test_email("test@example.com").deliver_now
+        get last_email_path
+        expect(response.body).to eq(LastEmailCache.instance.last_email_json)
+      end
+    end
+
+    context "when `Rails.configuration.use_last_email_cache` is \"false\"" do
+      before { allow(Rails.configuration).to receive(:use_last_email_cache).and_return(false) }
+
+      it "raises a routing error (404)" do
+        expect { get "/last-email" }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "when `Rails.configuration.use_last_email_cache` is missing" do
+      before { allow(Rails.configuration).to receive(:use_last_email_cache).and_return(nil) }
+
+      it "raises a routing error (404)" do
+        expect { get "/last-email" }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -18,4 +18,12 @@ module Helpers
   def date_outside_grace_window(expires_on)
     (expires_on + Rails.configuration.registration_grace_window)
   end
+
+  def generate_test_email(recipient)
+    ActionMailer::Base.mail(
+      from: "test@defra.gov.uk",
+      to: recipient,
+      body: "message"
+    )
+  end
 end


### PR DESCRIPTION
In order to improve the flow of the end-to-end tests, we want to add behaviour to the application that will support the storage of the last email that was sent. There will also be a route that returns the latest mail object as JSON.

The feature will be enabled through the use of an ENV var so we can ensure the endpoint is only accessible when the feature is explicitly enabled.