### PR TITLE
Fix last email cache body extraction

### DIFF
--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class TestMailer < ActionMailer::Base
+
+  FROM_ADDRESS = "Waste carriers test service"
+  SUBJECT = "Waste Carriers test email"
+  IMAGE_NAME = "govuk_logotype_email.png"
+
+  def base_email(recipient, body = nil)
+    body = "Test email" if body.nil?
+    mail(to: recipient, subject: SUBJECT, from: FROM_ADDRESS, body: body)
+  end
+
+  def basic_text_email(recipient, body = nil)
+    body = "Test email" if body.nil?
+    mail(to: recipient, subject: SUBJECT, from: FROM_ADDRESS, content_type: "text/plain", body: body)
+  end
+
+  def basic_html_email(recipient, body = nil)
+    body = "<h1>Test email</h1>" if body.nil?
+    mail(to: recipient, subject: SUBJECT, from: FROM_ADDRESS, content_type: "text/html", body: body)
+  end
+
+  def multipart_text_email(recipient)
+    # We have to add an attachment to force actionmailer to create a multipart
+    # email, else it will just generate a base plain text email.
+    add_logo_attachment
+    mail(to: recipient, subject: SUBJECT, from: FROM_ADDRESS) do |format|
+      format.text { render "test_email" }
+    end
+  end
+
+  def multipart_html_email(recipient)
+    # We have to add an attachment to force actionmailer to create a multipart
+    # email, else it will just generate a base html email.
+    add_logo_attachment
+    mail(to: recipient, subject: SUBJECT, from: FROM_ADDRESS) do |format|
+      format.html { render "test_email" }
+    end
+  end
+
+  def multipart_email(recipient)
+    # We have to add an attachment to force actionmailer to create a multipart
+    # email, else it will just generate a base html email.
+    add_logo_attachment
+    mail(to: recipient, subject: SUBJECT, from: FROM_ADDRESS) do |format|
+      format.text { render "test_email" }
+      format.html { render "test_email" }
+    end
+  end
+
+  private
+
+  def add_logo_attachment
+    path = Rails.root.join("app/assets/images/#{IMAGE_NAME}")
+    attachments[IMAGE_NAME] = File.read(path)
+  end
+
+end

--- a/app/views/test_mailer/test_email.html.erb
+++ b/app/views/test_mailer/test_email.html.erb
@@ -1,0 +1,3 @@
+<p>This is a html test email sent from the Waste Carriers Registration service.</p>
+
+<a href="https://github.com/DEFRA/waste-carriers-frontend">waste-carriers-frontend</a>

--- a/app/views/test_mailer/test_email.text.erb
+++ b/app/views/test_mailer/test_email.text.erb
@@ -1,0 +1,3 @@
+This is a text test email sent from the Waste Carriers Registration service.
+
+https://github.com/DEFRA/waste-carriers-frontend

--- a/lib/last_email_cache.rb
+++ b/lib/last_email_cache.rb
@@ -36,13 +36,20 @@ class LastEmailCache
 
   # If you've set multipart emails then you'll have both a text and a html
   # version (determined by adding the relevant erb views). If you do so then
-  # `my_mail.parts.length` will equal 2. If however you only have the one then
-  # `parts` doesn't seem to get populated. To cater for this we have this
-  # method to grab the body content
+  # `my_mail.parts.length` will at least equal 2. If you only have one of them
+  # e.g. just a text version then parts doesn't get populated.
+  #
+  # However any attachments will cause ActionMailer to use parts. So for example
+  # if we have a text only email with an attached image, then parts will be of
+  # length 2; one being the content and the other being the attachment.
+  #
+  # To cater for all possibilities we have this method to grab the body content
   # https://guides.rubyonrails.org/action_mailer_basics.html#sending-multipart-emails
+  # https://stackoverflow.com/a/15818886
   def email_body
-    return last_email.body.to_s if last_email.parts.empty?
+    part_to_use = last_email.text_part || last_email.html_part || last_email
 
-    last_email.text_part.to_s
+    # return the message body without the header information
+    part_to_use.body.decoded
   end
 end

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -5,16 +5,17 @@ require "spec_helper"
 RSpec.describe "Errors", type: :request do
   describe "GET /last-email" do
     context "when `Rails.configuration.use_last_email_cache` is \"true\"" do
+      let(:recipient) { "test@example.com" }
       before do
         allow(Rails.configuration).to receive(:use_last_email_cache).and_return(true)
       end
 
       it "returns the JSON value of the LastEmailCache", inject_interceptor: LastEmailCache do
-        generate_test_email("test@example.com").deliver_now
+        TestMailer.basic_text_email(recipient).deliver_now
         get last_email_path
         result = JSON.parse(response.body)
 
-        expect(result["last_email"]["to"]).to eq(["test@example.com"])
+        expect(result["last_email"]["to"]).to eq([recipient])
       end
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -18,12 +18,4 @@ module Helpers
   def date_outside_grace_window(expires_on)
     (expires_on + Rails.configuration.registration_grace_window)
   end
-
-  def generate_test_email(recipient)
-    ActionMailer::Base.mail(
-      from: "test@defra.gov.uk",
-      to: recipient,
-      body: "message"
-    )
-  end
 end


### PR DESCRIPTION
It turns out my understanding of how the main content or 'body' of an email is stored in the email message was flawed. It's actually even more complex as you have to factor in whether an attachment has been added or not.

If you've created a multipart email then you'll have both a text and a html version (determined by adding the relevant erb views). If you do so then `my_mail.parts.length` will at least equal 2. If you set only one of them when creating the email then parts doesn't get populated. ActionMailer just populates the root body and sets the content type accordingly.

However any attachments will cause ActionMailer to use parts irrespective of whether you set one, both or neither! So for example if we have a text only email with an attached image, then parts will be of length 2; one being the content and the other being the attachment.

This meant 3 main changes

- a tweak to the logic in the `LastEmailCache.email_body` to handle all these cases, with text content as the preference
- new tests to check the JSON result contains the body value we expect
- replacing the generate email helpers with a new mailer class

The last one was mainly out of frustration. As far as I could see we should be able to generate both standard and multipart emails dynamically. Below is an example I found in a couple of places

```ruby
  mail(to: 'example@example.com', subject: 'Welcome to My Awesome Site') do |format|
    format.html { render html: '<h1>Welcome XYZ!</h1>'.html_safe }
    format.text { render plain: 'Welcome XYZ' }
  end
```
https://stackoverflow.com/a/49630370

So this shouldn't need to rely on a template existing. However no matter what changes I made I always got `ActionView::MissingTemplate`. And it seems I'm not the only one to get this result. The comments in that stackoverflow post refer to differing results dependending on the version of Rails used, plus I [found another](https://stackoverflow.com/questions/53381094/how-to-send-multipart-email-without-a-template-in-rails-5-1?rq=1) hitting the same problem.

So in order to be able to test it can extract the content from multiple email types my only recourse was to ensure we have both a text and html template for testing. And if we were having those then we might as well move all the test emails into a `Testmailer` associated with the templates.