### PR TITLE
Refactor the rake test email task

### DIFF
--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -44,12 +44,4 @@ class RegistrationMailer < ActionMailer::Base
     subject = I18n.t('registration_mailer.account_already_confirmed.title')
     mail(to: user.email, subject: subject, from: from_address)
   end
-
-  def test_email
-    from_address = "#{Rails.configuration.registrations_service_emailName} <#{Rails.configuration.registrations_service_email}>"
-    subject = "Waste Carriers Test email"
-    mail(to: Rails.configuration.email_test_address, subject: subject, from: from_address) do |format|
-      format.text(content_type: "text/plain", charset: "UTF-8", content_transfer_encoding: "7bit")
-    end
-  end
 end

--- a/app/views/registration_mailer/test_email.text.erb
+++ b/app/views/registration_mailer/test_email.text.erb
@@ -1,3 +1,0 @@
-This is a test email sent from the Waste Carriers Registration service.
-
-https://github.com/DEFRA/waste-carriers-frontend

--- a/config/application.rb
+++ b/config/application.rb
@@ -213,8 +213,6 @@ module Registrations
     # 10 then the reg. is within the window and can still be renewed.
     config.registration_grace_window = (ENV["WCRS_REGISTRATION_GRACE_WINDOW"] || "3").to_i.days
 
-    config.email_test_address = ENV["WCRS_EMAIL_TEST_ADDRESS"] || "waste-carriers@example.com"
-
     config.assisted_digital_account_email = ENV["WCRS_ASSISTED_DIGITAL_EMAIL"]
 
     # Expose the data stored by the LastEmailCache. Only used in our acceptance

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 namespace :email do
-  desc "Send a test email to confirm confirm setup is correct"
+  desc "Send a test email to confirm setup is correct"
   task test: :environment do
-    puts RegistrationMailer.test_email.deliver_now
+    recipient = ENV["WCRS_EMAIL_TEST_ADDRESS"] || "waste-carriers@example.com"
+    puts TestMailer.basic_text_email(recipient).deliver_now
   end
 end


### PR DESCRIPTION
With the changes made in [PR 227](https://github.com/DEFRA/waste-carriers-frontend/pull/227) and [PR 228](https://github.com/DEFRA/waste-carriers-frontend/pull/228) we no longer need to use a mail in the `RegistrationMailer` class for testing if email is setup and working.

We now have a dedicated `TestMailer` with associated templates that can be used for this.

So this change is just a bit of housekeeping (akin to rearranging deck chairs on the titantic!)