### PR TITLE
Add test coverage for correct handling of 404 errors

### DIFF
--- a/spec/requests/page_not_found_spec.rb
+++ b/spec/requests/page_not_found_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Page not found", type: :request do
+  describe "GET /this-page-does-not-exist" do
+    it "redirects to `/errors/404`" do
+      rails_respond_without_detailed_exceptions do
+        get "/this-page-does-not-exist"
+
+        expect(response.code).to eq("404")
+      end
+    end
+  end
+end

--- a/spec/support/error_responses_helper.rb
+++ b/spec/support/error_responses_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ErrorResponses
+  def rails_respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config["action_dispatch.show_exceptions"]
+    original_show_detailed_exceptions = env_config["action_dispatch.show_detailed_exceptions"]
+    env_config["action_dispatch.show_exceptions"] = true
+    env_config["action_dispatch.show_detailed_exceptions"] = false
+    yield
+  ensure
+    env_config["action_dispatch.show_exceptions"] = original_show_exceptions
+    env_config["action_dispatch.show_detailed_exceptions"] = original_show_detailed_exceptions
+  end
+end
+
+RSpec.configure do |config|
+  config.include ErrorResponses
+end


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-261

This adds test coverage for the correct handling of 404 errors.
The fix on the engine as not been applied but looks like this project is
not affected by the issue. Yet I think is best to push this in for
both consistency and to prevent regression.