### PR TITLE
Renew link to point to verbal privacy policy

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module Registrations
       "#{base_url}#{path}"
     end
 
-    def renewal_privacy_policy_url(app_path)
+    def ad_verbal_privacy_policy_renewal_url(app_path)
       base_url = base_url(app_path)
 
       "#{base_url}/ad-privacy-policy/"
@@ -81,7 +81,7 @@ module Registrations
     config.waste_exemplar_addresses_url = ENV['WCRS_OS_PLACES_DOMAIN'] || 'http://localhost:8005'
 
     config.renewals_service_url = renewal_service_url("fo")
-    config.back_office_renewals_url = renewal_privacy_policy_url("bo")
+    config.back_office_renewals_url = ad_verbal_privacy_policy_renewal_url("bo")
 
     config.front_office_url = base_url("fo")
     config.back_office_url = base_url("bo")

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module Registrations
     def ad_verbal_privacy_policy_renewal_url(app_path)
       base_url = base_url(app_path)
 
-      "#{base_url}/bo/ad-privacy-policy/"
+      "#{base_url}/#{app_path}/ad-privacy-policy/"
     end
 
     def base_url(app_path)

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module Registrations
     def ad_verbal_privacy_policy_renewal_url(app_path)
       base_url = base_url(app_path)
 
-      "#{base_url}/ad-privacy-policy/"
+      "#{base_url}/bo/ad-privacy-policy/"
     end
 
     def base_url(app_path)

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,12 @@ module Registrations
       "#{base_url}#{path}"
     end
 
+    def renewal_privacy_policy_url(app_path)
+      base_url = base_url(app_path)
+
+      "#{base_url}/ad-privacy-policy/"
+    end
+
     def base_url(app_path)
       if Rails.env.production?
         # In production the base url needs to match the external url, hence we
@@ -75,7 +81,7 @@ module Registrations
     config.waste_exemplar_addresses_url = ENV['WCRS_OS_PLACES_DOMAIN'] || 'http://localhost:8005'
 
     config.renewals_service_url = renewal_service_url("fo")
-    config.back_office_renewals_url = renewal_service_url("bo")
+    config.back_office_renewals_url = renewal_privacy_policy_url("bo")
 
     config.front_office_url = base_url("fo")
     config.back_office_url = base_url("bo")


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-302

This updates the link to the renew page to point to the verbal privacy policy.

Depends on: https://github.com/DEFRA/waste-carriers-back-office/pull/340

<img width="490" alt="Screenshot 2019-07-18 at 16 31 16" src="https://user-images.githubusercontent.com/1385397/61470994-e767fe80-a979-11e9-8533-bff664932c87.png">
