### PR TITLE
Add link to accessibility statement

### DIFF
--- a/app/views/shared/_footer_top.html.erb
+++ b/app/views/shared/_footer_top.html.erb
@@ -3,5 +3,6 @@
   <ul>
     <li class="inline"><a href="<%= privacy_path %>" target="_blank"><%=t 'global.footer_privacy_link'%></a></li>
     <li class="inline"><a href="<%= cookies_path %>" target="_blank"><%=t 'global.footer_cookies_link'%></a></li>
+    <li class="inline"><a href="<%= "#{Rails.configuration.front_office_url}/fo/pages/accessibility" %>" target="_blank"><%=t 'global.footer_accessibility_link'%></a></li>
   </ul>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -423,6 +423,7 @@ en:
     footerLicence_html: "All content is available under the <a href='http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2'>Open Government Licence v2.0</a>, except where otherwise stated"
     footer_privacy_link: "Privacy\ "
     footer_cookies_link: "Cookies"
+    footer_accessibility_link: "Accessibility"
     headerLinkTitle: "Go to the GOV.UK homepage"
     helpline: "Helpline:\ "
     maintenance:


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-607

Add link to the accessibility statement in the front-office.
<img width="719" alt="Screenshot 2019-09-06 at 14 39 45" src="https://user-images.githubusercontent.com/1385397/64432383-46add980-d0b4-11e9-9352-21e33c44b337.png">
