### PR TITLE
Add page title to cookies page

### DIFF
--- a/app/views/home/cookies.html.erb
+++ b/app/views/home/cookies.html.erb
@@ -4,6 +4,8 @@
 
   <main id="content" role="main" class="group">
 
+    <% content_for :page_title, createTitle('.title') %>
+
     <header class="page-header group">
       <div class="hgroup">
         <h1 class="heading-xlarge"><%= t ".heading" %></h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,7 @@ en:
       title: "Key person details"
   home:
     cookies:
+      title: "Cookies"
       heading: "Cookies"
       cookie_text1: "The register as a waste carrier service puts small files (known as ‘cookies’) on to your computer. "
       cookie_text2: "These cookies are used to:"


### PR DESCRIPTION
The cookies page previously had a generic GOV.UK page title on frontend. Now fixed to read "Cookies" and be consistent with similar pages, such as the privacy policy.