### PR TITLE
Add link to Back Office NCCC login page - For vagrant

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -48,6 +48,7 @@
         <h2 class="heading-small">NCCC Entry points</h2>
           <ul>
             <li><a href='<%= new_agency_user_session_path %>'>Agency/NCCC Login </a></li>
+            <li><a href='http://localhost:8001/bo'>Back office/NCCC Login </a></li>
           </ul>
 
         <h2 class="heading-small">Administration Entry points</h2>


### PR DESCRIPTION
Since I keep forgetting how to get to the back office login page, I have added a link to it in the main page we root to localhost:3000 when running the vagrant machine for the project.