### PR TITLE
Add link to details page

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -1,6 +1,9 @@
 require 'json'
 
 module RegistrationsHelper
+  def back_office_details_url(reg_identifier)
+    "#{Rails.configuration.back_office_url}/bo/registrations/#{reg_identifier}"
+  end
 
   def validation_for(model, attribute)
     if model.errors[attribute].any?

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -205,6 +205,7 @@
           <nav aria-labelledby="parent-subsection" role="navigation">
             <ul class="actions-border">
               <li><span><%= t('.actions_heading') %></span><li>
+              <li><%= link_to t('form.details'), back_office_details_url(reg.regIdentifier) %></li>
               <% if reg.can_view_certificate? %><li><%= link_to t('registrations.form.view_button_label'), view_path(reg.uuid), target: '_blank' %></li><% end %>
               <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_button_label'), edit_path(reg.uuid, edit_process: RegistrationsController::EditMode::EDIT) %></li><% end %>
               <% if reg.can_be_deleted?(current_agency_user) %><li><%= link_to t('form.deregister_button_label'), confirmDelete_path(reg.uuid) %></li><% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -410,6 +410,7 @@ en:
     approve_button_label: "Approve registration"
     refuse_button_label: "Refuse registration"
     transfer_button_label: "Transfer to another account"
+    details: "Details"
   global:
     betaMessage: "BETA"
     betaMessage_html: "This is a new service - your <a href='https://www.gov.uk/done/waste-carrier-or-broker-registration' target='_blank'>feedback</a> will help us improve it."


### PR DESCRIPTION
Since we have now a working details page in the new back office, which links to the same features available for registrations in the back office, we want to make sure users can access the page from the old front office.

<img width="867" alt="Screenshot 2019-11-22 at 11 52 22" src="https://user-images.githubusercontent.com/1385397/69423773-ed525f80-0d1e-11ea-8d09-560c0e19495f.png">
