### PR TITLE
Remove approve and refuse links from backend dashboard

### DIFF
--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -215,12 +215,6 @@
                 <li><%= link_to t('form.transfer_button_label'), link_to_transfer(reg) %></li>
               <% end %>
               <% if reg.upper? %>
-                <% if reg.can_be_approved?(current_agency_user) %>
-                  <li><%= link_to t('form.approve_button_label'), approve_path(reg.uuid), id: "approveRegistration#{regCount}" %></li>
-                <% end %>
-                <% if reg.can_be_refused?(current_agency_user) %>
-                  <li><%= link_to t('form.refuse_button_label'), refuse_path(reg.uuid) %></li>
-                <% end %>
                 <% if reg.can_view_payment_status? %>
                   <li><%= link_to t('form.payment_status_button_label'), paymentstatus_url(reg.uuid), id: "paymentStatus#{regCount}" %></li>
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,10 +71,6 @@ Registrations::Application.routes.draw do
   get "registrations/:id/revoke" => 'registrations#revoke', :via => [:get], :as => :revoke
   get "registrations/:id/unrevoke" => 'registrations#unRevoke', :via => [:get], :as => :unrevoke
   match "registrations/:id/revoke" => 'registrations#updateRevoke', :via => [:post]
-  # Add routing for approve/refuse registration
-  get "registrations/:id/approve"   => 'registrations#approve', :via => [:get], :as => :approve
-  get "registrations/:id/refuse"    => 'registrations#refuse',  :via => [:get], :as => :refuse
-  match "registrations/:id/approve" => 'registrations#updateApprove', :via => [:post]
 
   get "registrations/find" => 'start#show', :as => :find
   get "registrations/(:reg_uuid)/start" => 'start#show', :as => :start


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-795

With the new convictions check workflow in place in the back office, we no longer want the old process to be accessible.

This PR removes the links and routes.