### PR TITLE
Remove links to revoke and delete

### DIFF
--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -208,8 +208,6 @@
               <li><%= link_to t('form.details'), back_office_details_url(reg) %></li>
               <% if reg.can_view_certificate? %><li><%= link_to t('registrations.form.view_button_label'), view_path(reg.uuid), target: '_blank' %></li><% end %>
               <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_button_label'), edit_path(reg.uuid, edit_process: RegistrationsController::EditMode::EDIT) %></li><% end %>
-              <% if reg.can_be_deleted?(current_agency_user) %><li><%= link_to t('form.deregister_button_label'), confirmDelete_path(reg.uuid) %></li><% end %>
-              <% if reg.is_revocable?(current_agency_user) %><li><%= link_to t('registrations.form.revoke_button_label'), revoke_path(reg.uuid), id: "revokeRegistration#{regCount}" %></li><% end %>
               <% if reg.is_unrevocable?(current_agency_user) %><li><%= link_to t('registrations.form.unrevoke_button_label'), unrevoke_path(reg.uuid) %></li><% end %>
               <% if reg.can_be_transferred?(current_agency_user) %>
                 <li><%= link_to t('form.transfer_button_label'), back_office_transfer_url(reg) %></li>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

Since we have now implemented the feature in the new back office, we are also removing links to the old version of the feature.