### PR TITLE
Redirect payment details to back office

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -350,4 +350,10 @@ module RegistrationsHelper
 
     "#{Rails.configuration.back_office_url}/#{reg_identifier}/order-copy-cards"
   end
+
+  def back_office_payment_details_url(registration)
+    reg_uuid = registration.uuid
+
+    "#{Rails.configuration.back_office_url}/resources/#{reg_uuid}/finance-details"
+  end
 end

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -214,7 +214,7 @@
               <% end %>
               <% if reg.upper? %>
                 <% if reg.can_view_payment_status? %>
-                  <li><%= link_to t('form.payment_status_button_label'), paymentstatus_url(reg.uuid), id: "paymentStatus#{regCount}" %></li>
+                  <li><%= link_to t('form.payment_status_button_label'), back_office_payment_details_url(reg), id: "paymentStatus#{regCount}" %></li>
                 <% end %>
                 <% if reg.can_renew? %>
                   <li><%= link_to t('form.renew_button_label'), back_office_renewals_url(reg) %></li>

--- a/spec/helpers/registrations_helper_spec.rb
+++ b/spec/helpers/registrations_helper_spec.rb
@@ -163,4 +163,12 @@ describe RegistrationsHelper do
       expect(helper.back_office_order_copy_cards_url(registration)).to eq(url)
     end
   end
+
+  describe "#back_office_payment_details_url" do
+    it "returns the correct URL" do
+      registration = build(:registration, uuid: "abcde12345")
+      url = "http://localhost:8001/bo/resources/abcde12345/finance-details"
+      expect(helper.back_office_payment_details_url(registration)).to eq(url)
+    end
+  end
 end


### PR DESCRIPTION
We have completely replaced all financial functionality in the service with new functions in the back-office. So going forward we want users to be directed there to use its functions, and not using the old ones in this app.

To help with that, when users click the 'Payment details' link we want them to be directed to the back office. Hence this change.