### PR TITLE
Redirect view certificate to back office

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -356,4 +356,10 @@ module RegistrationsHelper
 
     "#{Rails.configuration.back_office_url}/resources/#{reg_uuid}/finance-details"
   end
+
+  def back_office_view_certificate_url(registration)
+    reg_identifier = registration.regIdentifier
+
+    "#{Rails.configuration.back_office_url}/registrations/#{reg_identifier}/certificate"
+  end
 end

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -206,7 +206,7 @@
             <ul class="actions-border">
               <li><span><%= t('.actions_heading') %></span><li>
               <li><%= link_to t('form.details'), back_office_details_url(reg) %></li>
-              <% if reg.can_view_certificate? %><li><%= link_to t('registrations.form.view_button_label'), view_path(reg.uuid), target: '_blank' %></li><% end %>
+              <% if reg.can_view_certificate? %><li><%= link_to t('registrations.form.view_button_label'), back_office_view_certificate_url(reg) %></li><% end %>
               <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_button_label'), edit_path(reg.uuid, edit_process: RegistrationsController::EditMode::EDIT) %></li><% end %>
               <% if reg.is_unrevocable?(current_agency_user) %><li><%= link_to t('registrations.form.unrevoke_button_label'), unrevoke_path(reg.uuid) %></li><% end %>
               <% if reg.can_be_transferred?(current_agency_user) %>

--- a/spec/helpers/registrations_helper_spec.rb
+++ b/spec/helpers/registrations_helper_spec.rb
@@ -171,4 +171,12 @@ describe RegistrationsHelper do
       expect(helper.back_office_payment_details_url(registration)).to eq(url)
     end
   end
+
+  describe "#back_office_view_certificate_url" do
+    it "returns the correct URL" do
+      registration = build(:registration, regIdentifier: "CBDU99999")
+      url = "http://localhost:8001/bo/registrations/CBDU99999/certificate"
+      expect(helper.back_office_view_certificate_url(registration)).to eq(url)
+    end
+  end
 end


### PR DESCRIPTION
We have replaced the view certifcate feature in the service with a new version in the back-office. So going forward we want users to be directed there to use it, instead of the old version in this app.

To help with that, when users click the 'View certifcate' link we want them to be directed to the back office. Hence this change.