### PR TITLE
Update edit link to go to back office

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -345,6 +345,12 @@ module RegistrationsHelper
     "#{Rails.configuration.back_office_url}/registrations/#{reg_identifier}/transfer"
   end
 
+  def back_office_edit_url(registration)
+    reg_identifier = registration.regIdentifier
+
+    "#{Rails.configuration.back_office_url}/#{reg_identifier}/edit"
+  end
+
   def back_office_order_copy_cards_url(registration)
     reg_identifier = registration.regIdentifier
 

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -207,7 +207,7 @@
               <li><span><%= t('.actions_heading') %></span><li>
               <li><%= link_to t('form.details'), back_office_details_url(reg) %></li>
               <% if reg.can_view_certificate? %><li><%= link_to t('registrations.form.view_button_label'), back_office_view_certificate_url(reg) %></li><% end %>
-              <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_button_label'), edit_path(reg.uuid, edit_process: RegistrationsController::EditMode::EDIT) %></li><% end %>
+              <% if reg.can_be_edited?(current_agency_user) %><li><%= link_to t('registrations.form.edit_button_label'), back_office_edit_url(reg) %></li><% end %>
               <% if reg.is_unrevocable?(current_agency_user) %><li><%= link_to t('registrations.form.unrevoke_button_label'), unrevoke_path(reg.uuid) %></li><% end %>
               <% if reg.can_be_transferred?(current_agency_user) %>
                 <li><%= link_to t('form.transfer_button_label'), back_office_transfer_url(reg) %></li>

--- a/spec/helpers/registrations_helper_spec.rb
+++ b/spec/helpers/registrations_helper_spec.rb
@@ -156,6 +156,14 @@ describe RegistrationsHelper do
     end
   end
 
+  describe "#back_office_edit_url" do
+    it "returns the correct URL" do
+      registration = build(:registration, regIdentifier: "CBDU99999")
+      url = "http://localhost:8001/bo/CBDU99999/edit"
+      expect(helper.back_office_edit_url(registration)).to eq(url)
+    end
+  end
+
   describe "#back_office_order_copy_cards_url" do
     it "returns the correct URL" do
       registration = build(:registration, regIdentifier: "CBDU99999")


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-963

We now have an updated edit feature in the back office. This PR changes the existing backend link to go to the back office instead.