### PR TITLE
Fix agency link to Edit registration

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1232,7 +1232,7 @@ class Registration < Ohm::Model
   end
 
   def can_be_edited?(agency_user=nil)
-    (pending? || is_active?) && user_can_edit_registration(agency_user)
+    is_active? && user_can_edit_registration(agency_user)
   end
 
   def can_view_certificate?


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-963

With us replacing the Edit feature in this repo with a new version built into the [waste carriers back-office](https://github.com/DEFRA/waste-carriers-back-office) we want the Edit link here to now redirect to it.

This follows a similar pattern we have used for other functions. Where applicable, rather than remove a link to something that has been migrated we instead update the link. This just provides a little assistance to those still using the backend, and means they don't have to log in to the back-office and perform their search again.

However, it was spotted during QA there is a discrepancy between the 2 systems that needs to be handled. In this app, once a registration is created, even if payment and/or a conviction check is outstanding you can still perform an edit.

In the new version in the back-office, the registration must be complete. So we just need to tweak what we have done in the old app.

This change hides the link if the registration is in progress, bringing the backend inline with the back-office.

<details>
  <summary>Fixed - pending reg. with Edit link removed</summary>
  
![Screenshot 2020-04-08 at 17 09 32](https://user-images.githubusercontent.com/1789650/78807477-0a30bc00-79bc-11ea-9fe8-c99bc9101b22.png)

</details>