### PR TITLE
Redirect the registration journey to the new app

### DIFF
--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -3,6 +3,13 @@ class StartController < ApplicationController
 
   # GET /registrations/start
   def show
+    unless params[:do_no_redirect].present?
+      new_app_start_page_url = File.join(Rails.configuration.front_office_url, "start")
+
+      redirect_to new_app_start_page_url
+      return
+    end
+
     reg_uuid = params[:reg_uuid]
     @registration = if reg_uuid.present?
       # Edit an existing registration

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -3,7 +3,7 @@ class StartController < ApplicationController
 
   # GET /registrations/start
   def show
-    unless params[:do_no_redirect].present?
+    unless params[:do_not_redirect].present?
       new_app_start_page_url = File.join(Rails.configuration.front_office_url, "start")
 
       redirect_to new_app_start_page_url

--- a/app/views/shared/_current_user.html.erb
+++ b/app/views/shared/_current_user.html.erb
@@ -12,7 +12,7 @@
     </div>
     <% if !current_agency_user.has_any_role?({ :name => :Role_financeBasic, :resource => AgencyUser }, { :name => :Role_financeAdmin, :resource => AgencyUser }) %>
     <div>
-      <%= link_to t('.new_registration'), start_path, :id => "new_registration" %>
+      <%= link_to t('.new_registration'), File.join(Rails.configuration.back_office_url, "start"), :id => "new_registration" %>
     </div>
     <% end %>
     <div>

--- a/spec/controllers/start_spec.rb
+++ b/spec/controllers/start_spec.rb
@@ -1,19 +1,27 @@
 require 'spec_helper'
 
 describe StartController, :type => :controller do
-
   describe 'GET #show' do
+    it "returns a 302 response and redirects to the new app journey" do
+      allow(Rails.configuration).to receive(:front_office_url).and_return("http://localhost:3000/fo")
 
-    it 'responds successfully with a HTTP 200 status code' do
       get :show
-      expect(response.code).to eq('200')
+
+      expect(response.code).to eq("302")
+      expect(response).to redirect_to "http://localhost:3000/fo/start"
     end
 
-    it 'renders the #show template' do
-      get :show
-      expect(response).to render_template("show")
-    end
+    context "when the do_no_redirect params is passed in" do
+      it 'responds successfully with a HTTP 200 status code' do
+        get :show, do_no_redirect: 1
+        expect(response.code).to eq("200")
+      end
 
+      it 'renders the #show template' do
+        get :show, do_no_redirect: 1
+        expect(response).to render_template("show")
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/controllers/start_spec.rb
+++ b/spec/controllers/start_spec.rb
@@ -13,12 +13,12 @@ describe StartController, :type => :controller do
 
     context "when the do_not_redirect params is passed in" do
       it 'responds successfully with a HTTP 200 status code' do
-        get :show, do_no_redirect: 1
+        get :show, do_not_redirect: 1
         expect(response.code).to eq("200")
       end
 
       it 'renders the #show template' do
-        get :show, do_no_redirect: 1
+        get :show, do_not_redirect: 1
         expect(response).to render_template("show")
       end
     end

--- a/spec/controllers/start_spec.rb
+++ b/spec/controllers/start_spec.rb
@@ -11,7 +11,7 @@ describe StartController, :type => :controller do
       expect(response).to redirect_to "http://localhost:3000/fo/start"
     end
 
-    context "when the do_no_redirect params is passed in" do
+    context "when the do_not_redirect params is passed in" do
       it 'responds successfully with a HTTP 200 status code' do
         get :show, do_no_redirect: 1
         expect(response.code).to eq("200")


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1009

This implement a simple redirect hack that will bring the user to the new journey. It is possible to avoid the redirect by using the `do_not_redirect` param.