### PR TITLE
Fix broken renew link in backend

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -336,7 +336,7 @@ module RegistrationsHelper
   def back_office_renewals_url(registration)
     reg_identifier = registration.regIdentifier
 
-    "#{Rails.configuration.back_office_url}/ad-privacy-policy/#{reg_identifier}"
+    "#{Rails.configuration.back_office_url}/ad-privacy-policy?reg_identifier=#{reg_identifier}"
   end
 
   def back_office_transfer_url(registration)

--- a/spec/helpers/registrations_helper_spec.rb
+++ b/spec/helpers/registrations_helper_spec.rb
@@ -143,7 +143,8 @@ describe RegistrationsHelper do
   describe "#back_office_renewals_url" do
     it "returns the correct URL" do
       registration = build(:registration, regIdentifier: "CBDU99999")
-      url = "http://localhost:8001/bo/ad-privacy-policy/CBDU99999"
+      # url = "http://localhost:8001/bo/ad-privacy-policy/CBDU99999"
+      url = "http://localhost:8001/bo/ad-privacy-policy?reg_identifier=CBDU99999"
       expect(helper.back_office_renewals_url(registration)).to eq(url)
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1098

During regression testing of the next release, we spotted that the link to renew a registration from the backend is broken.

It currently takes you to https://admin-waste-carriers-pre.aws.defra.cloud/bo/ad-privacy-policy/CBDU47. It should take you to https://admin-waste-carriers-pre.aws.defra.cloud/bo/ad-privacy-policy?reg_identifier=CBDU47