### PR TITLE
Set path for create new reg. based on feat. toggle

### DIFF
--- a/app/views/shared/_current_user.html.erb
+++ b/app/views/shared/_current_user.html.erb
@@ -12,7 +12,11 @@
     </div>
     <% if !current_agency_user.has_any_role?({ :name => :Role_financeBasic, :resource => AgencyUser }, { :name => :Role_financeAdmin, :resource => AgencyUser }) %>
     <div>
-      <%= link_to t('.new_registration'), File.join(Rails.configuration.back_office_url, "ad-privacy-policy"), :id => "new_registration" %>
+      <% if FeatureToggle.active?(:new_registration) %>
+        <%= link_to t('.new_registration'), File.join(Rails.configuration.back_office_url, "ad-privacy-policy"), :id => "new_registration" %>
+      <% else %>
+        <%= link_to t('.new_registration'), start_path, :id => "new_registration" %>
+      <% end %>
     </div>
     <% end %>
     <div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1163

RUBY-1163 highlights a bug that occurs because of users being forced to return to the old backend app from the new back-office to create a registration. In this case if the user is not already logged into the backend they'll be able to start a registration but eventually (at the 'What type of business are you?' page) it will throw up the sign-in page and lose the progress so far.

This is actually because the 'New or renew' and 'Location' pages were added to the journey later in WCR's life. Business type is the first of the old-old code and where the app starts to check user credentials.

We've always known there are issues and problems with switching between the apps. But we have not wanted to invest too much time in trying to resolve them because we are more focused on moving to just having one app.

Case in point, currently to create a new registration you must first log into this project and do it from here because we know it will lead to these issues.

So to fix RUBY-1118 we need to update the logic for the 'New registration' link. If `:new_registration` is enabled the link should take you to the AD privacy policy page in the new back-office app. If disabled then it should take you to the start of the registrations journey and not redirect you to the new back-office. This means users are required to log int the backend to create new registrations, which nullifies this issue and others like it.